### PR TITLE
Lift accessors into header files where possible.

### DIFF
--- a/include/gtirb/Block.hpp
+++ b/include/gtirb/Block.hpp
@@ -49,9 +49,9 @@ public:
   ///
   ~Block() override = default;
 
-  Addr getAddress() const;
-  uint64_t getSize() const;
-  uint64_t getDecodeMode() const;
+  Addr getAddress() const { return Address; }
+  uint64_t getSize() const { return Size; }
+  uint64_t getDecodeMode() const { return DecodeMode; }
 
   using MessageType = proto::Block;
   void toProtobuf(MessageType* Message) const;

--- a/include/gtirb/DataObject.hpp
+++ b/include/gtirb/DataObject.hpp
@@ -37,9 +37,9 @@ public:
   ///
   DataObject& operator=(DataObject&&) = default;
 
-  Addr getAddress() const;
+  Addr getAddress() const { return Address; }
 
-  uint64_t getSize() const;
+  uint64_t getSize() const { return Size; }
 
   using MessageType = proto::DataObject;
   void toProtobuf(MessageType* Message) const;

--- a/include/gtirb/IR.hpp
+++ b/include/gtirb/IR.hpp
@@ -4,6 +4,7 @@
 #include <gtirb/Addr.hpp>
 #include <gtirb/Node.hpp>
 #include <gtirb/Table.hpp>
+#include <map>
 #include <memory>
 #include <vector>
 
@@ -80,8 +81,8 @@ public:
   ///
   ~IR() override;
 
-  std::vector<Module>& getModules();
-  const std::vector<Module>& getModules() const;
+  std::vector<Module>& getModules() { return Modules; }
+  const std::vector<Module>& getModules() const { return Modules; }
 
   ///
   /// Get all modules having the given Preferred address
@@ -149,19 +150,19 @@ public:
   ///
   /// \return     The total number of tables this node owns.
   ///
-  size_t getTableSize() const;
+  size_t getTableSize() const { return Tables.size(); }
 
   ///
   /// Test to see if the number of tables at this Node is zero.
   ///
   /// \return     True if this node does not own any tables.
   ///
-  bool getTablesEmpty() const;
+  bool getTablesEmpty() const { return Tables.empty(); }
 
   ///
   /// Clear all locally owned tables.
   ///
-  void clearTables();
+  void clearTables() { Tables.clear(); }
 
 private:
   std::map<std::string, gtirb::Table> Tables;

--- a/include/gtirb/ImageByteMap.hpp
+++ b/include/gtirb/ImageByteMap.hpp
@@ -46,32 +46,32 @@ public:
   ///
   /// \return     Sets the file name of the image.
   ///
-  void setFileName(std::string X);
+  void setFileName(const std::string& X) { FileName = X; }
 
   ///
   /// \return     The loaded file name and path.
   ///
-  std::string getFileName() const;
+  const std::string& getFileName() const { return FileName; }
 
   ///
   /// Sets the base address of loaded file.
   ///
-  void setBaseAddress(Addr X);
+  void setBaseAddress(Addr X) { BaseAddress = X; }
 
   ///
   /// Gets the base addrress of loaded file.
   ///
-  Addr getBaseAddress() const;
+  Addr getBaseAddress() const { return BaseAddress; }
 
   ///
   /// Sets the entry point of loaded file.
   ///
-  void setEntryPointAddress(Addr X);
+  void setEntryPointAddress(Addr X) { EntryPointAddress = X; }
 
   ///
   /// Gets the entry point of loaded file.
   ///
-  Addr getEntryPointAddress() const;
+  Addr getEntryPointAddress() const { return EntryPointAddress; }
 
   ///
   /// If an invalid pair is passed in, the min and max will be set to an invalid
@@ -91,17 +91,17 @@ public:
   /// \return     The minimum and maximum effective address (Addr) for this
   /// Module.
   ///
-  std::pair<Addr, Addr> getAddrMinMax() const;
+  std::pair<Addr, Addr> getAddrMinMax() const { return EaMinMax; }
 
   ///
   ///
   ///
-  void setRebaseDelta(int64_t X);
+  void setRebaseDelta(int64_t X) { RebaseDelta = X; }
 
   ///
   ///
   ///
-  int64_t getRebaseDelta() const;
+  int64_t getRebaseDelta() const { return RebaseDelta; }
 
   ///
   /// Marks the loaded image as having been relocated.
@@ -109,22 +109,22 @@ public:
   /// This is primarily useful for loaders that load from sources that provide
   /// already-relocated content.
   ///
-  void setIsRelocated();
+  void setIsRelocated() { IsRelocated = true; }
 
   ///
   /// \return     True if the loaded image has been relocated.
   ///
-  bool getIsRelocated() const;
+  bool getIsRelocated() const { return IsRelocated; }
 
   ///
   /// Set the byte order to use when getting or setting data.
   ///
-  boost::endian::order getByteOrder() const;
+  boost::endian::order getByteOrder() const { return ByteOrder; }
 
   ///
   /// Get the byte order used when getting or setting data.
   ///
-  void setByteOrder(boost::endian::order Value);
+  void setByteOrder(boost::endian::order Value) { ByteOrder = Value; }
 
   ///
   /// Sets byte map at the given address. Data is written directly without

--- a/include/gtirb/Module.hpp
+++ b/include/gtirb/Module.hpp
@@ -89,14 +89,14 @@ public:
   ///
   /// \param  X   A path to the corresponding binary on disk.
   ///
-  void setBinaryPath(std::string X);
+  void setBinaryPath(const std::string& X) { BinaryPath = X; }
 
   ///
   /// Get the location of the corresponding binary on disk.
   ///
   /// \return   The path to the corresponding binary on disk.
   ///
-  std::string getBinaryPath() const;
+  const std::string& getBinaryPath() const { return BinaryPath; }
 
   ///
   /// Sets the format of the binary pointed to by getBinaryPath().
@@ -104,7 +104,7 @@ public:
   /// \param  X   The gtirb::FileFormat enumeration corresponding to the binary
   /// associated with this Module.
   ///
-  void setFileFormat(gtirb::FileFormat X);
+  void setFileFormat(gtirb::FileFormat X) { this->FileFormat = X; }
 
   ///
   /// Gets the format of the binary pointed to by getBinaryPath().
@@ -112,37 +112,37 @@ public:
   /// \return     The gtirb::FileFormat enumeration corresponding to the binary
   /// associated with this Module.
   ///
-  gtirb::FileFormat getFileFormat() const;
+  gtirb::FileFormat getFileFormat() const { return this->FileFormat; }
 
   ///
   ///
   ///
-  void setRebaseDelta(int64_t X);
+  void setRebaseDelta(int64_t X) { RebaseDelta = X; }
 
   ///
   ///
   ///
-  int64_t getRebaseDelta() const;
+  int64_t getRebaseDelta() const { return RebaseDelta; }
 
   ///
   ///
   ///
-  void setPreferredAddr(Addr X);
+  void setPreferredAddr(gtirb::Addr X) { PreferredAddr = X; }
 
   ///
   ///
   ///
-  void setISAID(gtirb::ISAID X);
+  void setISAID(gtirb::ISAID X) { IsaID = X; }
 
   ///
   ///
   ///
-  gtirb::ISAID getISAID() const;
+  gtirb::ISAID getISAID() const { return IsaID; }
 
   ///
   ///
   ///
-  Addr getPreferredAddr() const;
+  gtirb::Addr getPreferredAddr() const { return PreferredAddr; }
 
   ///
   /// A Module can have exactly one ImageByteMap child.
@@ -153,8 +153,8 @@ public:
   gtirb::SymbolSet& getSymbols();
   const gtirb::SymbolSet& getSymbols() const;
 
-  void setName(std::string X);
-  std::string getName() const;
+  void setName(const std::string& X) { Name = X; }
+  const std::string& getName() const { return Name; }
 
   const CFG& getCFG() const;
   CFG& getCFG();

--- a/include/gtirb/Node.hpp
+++ b/include/gtirb/Node.hpp
@@ -73,7 +73,7 @@ public:
   ///
   /// Retrieve the Node's Universally Unique ID (UUID).
   ///
-  UUID getUUID() const;
+  UUID getUUID() const { return Uuid; }
 
 private:
   UUID Uuid;

--- a/include/gtirb/Section.hpp
+++ b/include/gtirb/Section.hpp
@@ -34,9 +34,9 @@ public:
   bool operator==(const Section& Other) const;
   bool operator!=(const Section& Other) const;
 
-  const std::string& getName() const;
-  const Addr getAddress() const;
-  uint64_t getSize() const;
+  const std::string& getName() const { return Name; }
+  const Addr getAddress() const { return Address; }
+  uint64_t getSize() const { return Size; }
 
   using MessageType = proto::Section;
   void toProtobuf(MessageType* Message) const;

--- a/include/gtirb/Symbol.hpp
+++ b/include/gtirb/Symbol.hpp
@@ -63,11 +63,11 @@ public:
   ///
   ~Symbol() override = default;
 
-  void setAddress(gtirb::Addr X);
-  gtirb::Addr getAddress() const;
+  void setAddress(gtirb::Addr X) { Address = X; }
+  gtirb::Addr getAddress() const { return Address; }
 
-  void setName(std::string X);
-  std::string getName() const;
+  void setName(const std::string& X) { Name = X; }
+  const std::string& getName() const { return Name; }
 
   ///
   /// Set the DataObject to which this symbol refers.
@@ -82,15 +82,15 @@ public:
   ///
   /// Get the DataObject to which this symbol refers.
   ///
-  NodeRef<DataObject> getDataReferent() const;
+  NodeRef<DataObject> getDataReferent() const { return DataReferent; }
 
   ///
   /// Get the Block object to which this symbol refers.
   ///
-  NodeRef<Block> getCodeReferent() const;
+  NodeRef<Block> getCodeReferent() const { return CodeReferent; }
 
-  void setStorageKind(Symbol::StorageKind X);
-  gtirb::Symbol::StorageKind getStorageKind() const;
+  void setStorageKind(Symbol::StorageKind X) { Storage = X; }
+  gtirb::Symbol::StorageKind getStorageKind() const { return Storage; }
 
   using MessageType = proto::Symbol;
   void toProtobuf(MessageType* Message) const;

--- a/src/Block.cpp
+++ b/src/Block.cpp
@@ -8,12 +8,6 @@ using namespace gtirb;
 Block::Block(Addr Address_, uint64_t Size_, uint64_t DecodeMode_)
     : Node(), Address(Address_), Size(Size_), DecodeMode(DecodeMode_) {}
 
-Addr Block::getAddress() const { return this->Address; }
-
-uint64_t Block::getSize() const { return this->Size; }
-
-uint64_t Block::getDecodeMode() const { return this->DecodeMode; }
-
 void Block::toProtobuf(MessageType* Message) const {
   nodeUUIDToBytes(this, *Message->mutable_uuid());
   Message->set_address(static_cast<uint64_t>(this->Address));

--- a/src/DataObject.cpp
+++ b/src/DataObject.cpp
@@ -4,10 +4,6 @@
 
 using namespace gtirb;
 
-Addr DataObject::getAddress() const { return this->Address; }
-
-uint64_t DataObject::getSize() const { return this->Size; }
-
 void DataObject::toProtobuf(MessageType* Message) const {
   nodeUUIDToBytes(this, *Message->mutable_uuid());
   Message->set_address(static_cast<uint64_t>(this->Address));

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -16,10 +16,6 @@ IR::IR(IR&&) = default;
 IR& IR::operator=(IR&&) = default;
 IR::~IR() = default;
 
-std::vector<Module>& IR::getModules() { return this->Modules; }
-
-const std::vector<Module>& IR::getModules() const { return this->Modules; }
-
 std::vector<const Module*> IR::getModulesWithPreferredAddr(Addr X) const {
   std::vector<const Module*> Results;
 
@@ -77,12 +73,6 @@ bool IR::removeTable(const std::string& X) {
 
   return false;
 }
-
-size_t IR::getTableSize() const { return this->Tables.size(); }
-
-bool IR::getTablesEmpty() const { return this->Tables.empty(); }
-
-void IR::clearTables() { this->Tables.clear(); }
 
 void IR::toProtobuf(MessageType* Message) const {
   nodeUUIDToBytes(this, *Message->mutable_uuid());

--- a/src/ImageByteMap.cpp
+++ b/src/ImageByteMap.cpp
@@ -4,20 +4,6 @@
 
 using namespace gtirb;
 
-void ImageByteMap::setFileName(std::string X) { this->FileName = X; }
-
-std::string ImageByteMap::getFileName() const { return this->FileName; }
-
-void ImageByteMap::setBaseAddress(Addr X) { this->BaseAddress = X; }
-
-Addr ImageByteMap::getBaseAddress() const { return this->BaseAddress; }
-
-void ImageByteMap::setEntryPointAddress(Addr X) { this->EntryPointAddress = X; }
-
-Addr ImageByteMap::getEntryPointAddress() const {
-  return this->EntryPointAddress;
-}
-
 bool ImageByteMap::setAddrMinMax(std::pair<Addr, Addr> X) {
   if (X.first <= X.second) {
     this->EaMinMax = std::move(X);
@@ -26,26 +12,6 @@ bool ImageByteMap::setAddrMinMax(std::pair<Addr, Addr> X) {
 
   this->EaMinMax = std::make_pair(Addr{}, Addr{});
   return false;
-}
-
-std::pair<Addr, Addr> ImageByteMap::getAddrMinMax() const {
-  return this->EaMinMax;
-}
-
-void ImageByteMap::setRebaseDelta(int64_t X) { this->RebaseDelta = X; }
-
-int64_t ImageByteMap::getRebaseDelta() const { return this->RebaseDelta; }
-
-void ImageByteMap::setIsRelocated() { this->IsRelocated = true; }
-
-bool ImageByteMap::getIsRelocated() const { return this->IsRelocated; }
-
-boost::endian::order ImageByteMap::getByteOrder() const {
-  return this->ByteOrder;
-}
-
-void ImageByteMap::setByteOrder(boost::endian::order Value) {
-  this->ByteOrder = Value;
 }
 
 void ImageByteMap::setData(Addr Ea, gsl::span<const std::byte> Data) {

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -24,26 +24,6 @@ Module::Module()
 Module::Module(Module&&) = default;
 Module::~Module() = default;
 
-void Module::setBinaryPath(std::string X) { this->BinaryPath = X; }
-
-std::string Module::getBinaryPath() const { return this->BinaryPath; }
-
-void Module::setFileFormat(gtirb::FileFormat X) { this->FileFormat = X; }
-
-gtirb::FileFormat Module::getFileFormat() const { return this->FileFormat; }
-
-void Module::setRebaseDelta(int64_t X) { this->RebaseDelta = X; }
-
-int64_t Module::getRebaseDelta() const { return this->RebaseDelta; }
-
-void Module::setISAID(gtirb::ISAID X) { this->IsaID = X; }
-
-gtirb::ISAID Module::getISAID() const { return this->IsaID; }
-
-void Module::setPreferredAddr(Addr X) { this->PreferredAddr = X; }
-
-Addr Module::getPreferredAddr() const { return this->PreferredAddr; }
-
 gtirb::SymbolSet& Module::getSymbols() { return *this->Symbols; }
 
 const gtirb::SymbolSet& Module::getSymbols() const { return *this->Symbols; }
@@ -55,10 +35,6 @@ gtirb::ImageByteMap& Module::getImageByteMap() {
 const gtirb::ImageByteMap& Module::getImageByteMap() const {
   return *this->ImageByteMap_.get();
 }
-
-void Module::setName(std::string X) { this->Name = std::move(X); }
-
-std::string Module::getName() const { return this->Name; }
 
 const CFG& Module::getCFG() const { return *this->Cfg; }
 

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -66,8 +66,6 @@ void Node::setUUID(UUID X) {
   Node::UuidMap.emplace(X, this);
 }
 
-UUID Node::getUUID() const { return this->Uuid; }
-
 std::string gtirb::uuidToString(const UUID& Uuid) {
   return boost::uuids::to_string(Uuid);
 }

--- a/src/Section.cpp
+++ b/src/Section.cpp
@@ -7,12 +7,6 @@ using namespace gtirb;
 Section::Section(std::string N, Addr A, uint64_t S)
     : Node(), Name(N), Address(A), Size(S) {}
 
-const std::string& Section::getName() const { return this->Name; }
-
-uint64_t Section::getSize() const { return this->Size; }
-
-const Addr Section::getAddress() const { return this->Address; }
-
 bool Section::operator==(const Section& Other) const {
   return this->Address == Other.Address && this->Size == Other.Size &&
          this->Name == Other.Name;

--- a/src/Symbol.cpp
+++ b/src/Symbol.cpp
@@ -22,14 +22,6 @@ Symbol::Symbol(Addr X, std::string Name_, const Block& Referent,
   this->setReferent(Referent);
 }
 
-void Symbol::setAddress(Addr X) { this->Address = X; }
-
-Addr Symbol::getAddress() const { return this->Address; }
-
-void Symbol::setName(std::string X) { this->Name = X; }
-
-std::string Symbol::getName() const { return this->Name; }
-
 void Symbol::setReferent(const DataObject& Data) {
   this->DataReferent = NodeRef<DataObject>(Data);
   this->CodeReferent = {};
@@ -38,18 +30,6 @@ void Symbol::setReferent(const DataObject& Data) {
 void Symbol::setReferent(const Block& Instruction) {
   this->CodeReferent = NodeRef<Block>(Instruction);
   this->DataReferent = {};
-}
-
-NodeRef<DataObject> Symbol::getDataReferent() const {
-  return this->DataReferent;
-}
-
-NodeRef<Block> Symbol::getCodeReferent() const { return this->CodeReferent; }
-
-void Symbol::setStorageKind(Symbol::StorageKind X) { this->Storage = X; }
-
-gtirb::Symbol::StorageKind Symbol::getStorageKind() const {
-  return this->Storage;
 }
 
 void Symbol::toProtobuf(MessageType* Message) const {


### PR DESCRIPTION
Should be pretty self-explanatory, but this moves accessors into header files whenever possible so that optimizers don't have to work so hard to inline trivial accessors. There should be almost no functional changes here, except there were a few places where accessors should have been dealing with references but were instead dealing with value types.