### PR TITLE
Mark up AB's notes at top of Casting.hpp to make a documentation page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,7 @@ information.
 
 ### Building Documentation
 
+You will need `cmake` and `Doxygen`.
 
 1. Create and change to a temporary build directory. 
 
@@ -65,7 +66,7 @@ information.
 
    ```bash
    build> cmake <PATH_TO_GTIRB>/doc/doxy/
-   build> make doc
+   build> cmake --build . --target doc
    ```
 
 3. [optional] Delete the temporary build directory

--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ Boost.
 
 2. **Install Git**
 
-Git is required to fetch the source code. Install with a package
-manager or from https://git-scm.com/download/win on Windows. Choose
-the option that adds git and minimal tools to the path.
+   Git is required to fetch the source code. Install with a package
+   manager or from https://git-scm.com/download/win on Windows. Choose
+   the option that adds git and minimal tools to the path.
 
 3. **Install Dependencies**
 

--- a/include/gtirb/Casting.hpp
+++ b/include/gtirb/Casting.hpp
@@ -7,55 +7,177 @@
 #include <cassert>
 #include <type_traits>
 
-/* Casting Synopsis
+/// \file Casting.hpp 
+///
+/// This file defines the various casting and type checking operations
+/// that apply to gtirb::Node subclasses. For full details, see \ref casting.
 
-Node and its subclasses support custom casting machinery that allows for type
-checking, safer static casting, and safe dynamic casting without needing the
-overhead of a vtable or RTTI. This file defines the various operations that
-apply to Node subclasses.
+/// \page casting Casting
+///
+/// gtirb::Node and its subclasses support custom casting machinery that
+/// allows for type checking, safer static casting, and safe dynamic
+/// casting without needing the overhead of a vtable or RTTI. File
+/// Casting.hpp defines the various operations that apply to gtirb::Node
+/// subclasses.
+/// 
+/// - \ref ISA "isa<Ty>" Performs a type check. 
+/// - \ref CAST "cast<Ty>" Returns the given argument cast to the
+///   specified type;  the argument cannot be null.
+/// - \ref CAST_OR_NULL "cast_or_null<Ty>" Returns the given argument
+///   cast to the specified type; the argument can be null.
+/// - \ref DYN_CAST "dyn_cast<Ty>" Returns the given argument cast to
+///   the specified type, or null if the casting operation fails
+///   because the types do not match; the argument cannot be null.
+/// - \ref DYN_CAST_OR_NULL "dyn_cast_or_null<Ty>" Returns the given
+///   argument cast to the specified type, or null if the casting 
+///   operation fails because the types do not match; the argument can
+///   be null.
+///
+///
+/// \section ISA isa<Ty>
+///
+/// Perform a type check.
+/// 
+/// \param Val The object to check. Cannot be null.
+/// 
+/// \return \c true if \p Val is an instance of the template parameter
+/// type, \c false otherwise.
+/// 
+/// - isa<Ty>(const Y& Val)
+///
+/// Example usage:
+/// \code
+/// void f(Node *N) { if (isa<Block>(N) { ... } }
+/// \endcode
+///
+///
+/// \section  CAST cast<Ty>
+///
+/// Cast to the specified type; the argument cannot be null.
+///
+/// \param Val the value to cast. Cannot be null; consider using
+/// \ref CAST_OR_NULL "cast_or_null<Ty>" in that case.
+///
+/// \return The result of casting \p Val to the specified type.
+///   This function asserts that the types match and will not return
+///   null on failure.
+///
+/// - cast<Ty>(Y* Val)
+/// - cast<Ty>(Y& Val)
+/// - cast<Ty>(const Y& Val)
+///
+/// Example usage:
+/// \code
+/// void f(gsl::not_null<Node *> N) { auto *B = cast<Block>(N); }
+/// \endcode
+///
+/// 
+/// \section CAST_OR_NULL cast_or_null<Ty>
+///
+/// Cast to the specified type; the argument can be null.
+///
+/// \param Val the value to cast. Can be null.
+///
+/// \return The result of casting \p Val to the specified type.
+///   This function asserts that the types match and will not return
+///   null on failure. If \p Val is null, returns a null pointer cast
+///   to the given type.
+///
+/// - cast_or_null<Ty>(Y* Val)
+/// - cast_or_null<Ty>(Y& Val)
+/// - cast_or_null<Ty>(const Y& Val)
+///
+/// Example usage:
+/// \code
+///  void f(Node *N) { auto *B = cast_or_null<Block>(N); }
+/// \endcode
+///
+///
+/// \section  DYN_CAST dyn_cast<Ty>
+///
+/// Dynamic cast to the specified type; the argument cannot be null.
+///
+/// \param Val the value to cast. Cannot be null; consider using
+/// \ref DYN_CAST_OR_NULL "dyn_cast_or_null<Ty>" in that case.
+///
+/// \return The result of casting \p Val to the specified type, or
+/// null if the casting operation fails because the types do not
+/// match.
+///
+/// - dyn_cast<Ty>(Y* Val)
+/// - dyn_cast<Ty>(Y& Val)
+/// - dyn_cast<Ty>(const Y& Val)
+///
+/// Example usage:
+/// \code
+/// void f(gsl::not_null<Node *> N) { auto *B = dyn_cast<Block>(N); }
+/// \endcode
+///
+/// 
+/// \section DYN_CAST_OR_NULL dyn_cast_or_null<Ty>
+///
+/// Cast to the specified type; the argument can be null.
+///
+/// \param Val the value to cast. Can be null.
+///
+/// \return The result of casting \p Val to the specified type, or
+/// null if the casting operation fails because the types do not
+/// match. If \p Val is null, returns a null pointer cast to the given
+/// type.
+/// 
+/// - dyn_cast_or_null<Ty>(Y* Val)
+/// - dyn_cast_or_null<Ty>(Y& Val)
+/// - dyn_cast_or_null<Ty>(const Y& Val)
+///
+/// Example usage:
+/// \code
+/// void f(Node *N) { auto *B = dyn_cast_or_null<Block>(N); }
+/// \endcode
 
-isa<Ty>
-Performs a type check. Returns true if the given object is an instance of the
-template parameter type, and false otherwise. The given object cannot be null.
-Example usage:
+/// \fn isa(const Y& Val)
+/// See \ref ISA.
 
-  void f(Node *N) { if (isa<Block>(N) { ... } }
+/// \fn cast(Y* Val)
+/// See \ref CAST.
 
-cast<Ty>
-Returns the given argument cast to the specified type. This function asserts
-that the types match and will not return null on failure. The given object
-cannot be null; consider using cast_or_null<Ty> in that case. Example usage:
+/// \fn cast(Y& Val)
+/// See \ref CAST.
 
-  void f(gsl::not_null<Node *> N) { auto *B = cast<Block>(N); }
+/// \fn cast(const Y& Val)
+/// See \ref CAST.
 
-cast_or_null<Ty>
-Returns the given argument cast to the specified type. This function asserts
-that the types match and will not return null on failure. The given object can
-be null, in which case the result will be a null pointer cast to the given type.
-Example usage:
+/// \fn cast_or_null(Y* Val)
+/// See \ref CAST_OR_NULL.
 
-  void f(Node *N) { auto *B = cast_or_null<Block>(N); }
+/// \fn cast_or_null(Y& Val)
+/// See \ref CAST_OR_NULL.
 
-dyn_cast<Ty>
-Returns the given argument cast to the specified type, or null if the casting
-operation fails because the types do not match. The given object cannot be null;
-consider using dyn_cast_or_null<Ty> in that case. Example usage:
+/// \fn cast_or_null(const Y& Val)
+/// See \ref CAST_OR_NULL.
 
-  void f(gsl::not_null<Node *> N) { auto *B = dyn_cast<Block>(N); }
+/// \fn dyn_cast(Y* Val)
+/// See \ref DYN_CAST.
 
-dyn_cast_or_null<Ty>
-Returns the given argument cast to the specified type, or null if the casting
-operation fails because the types do not match. The given object can be null, in
-which case the result will be a null pointer cast to the given type. Example
-usage:
+/// \fn dyn_cast(Y& Val)
+/// See \ref DYN_CAST.
 
-  void f(Node *N) { auto *B = dyn_cast_or_null<Block>(N); }
-*/
+/// \fn dyn_cast(const Y& Val)
+/// See \ref DYN_CAST.
+
+/// \fn dyn_cast_or_null(Y* Val)
+/// See \ref DYN_CAST_OR_NULL.
+
+/// \fn dyn_cast_or_null(Y& Val)
+/// See \ref DYN_CAST_OR_NULL.
+
+/// \fn dyn_cast_or_null(const Y& Val)
+/// See \ref DYN_CAST_OR_NULL.
 
 //===----------------------------------------------------------------------===//
 //                          isa<x> Support Templates
 //===----------------------------------------------------------------------===//
 
+/// @cond INTERNAL
 // Define a template that can be specialized by smart pointers to reflect the
 // fact that they are automatically dereferenced, and are not involved with the
 // template selection process...  the default implementation is a noop.
@@ -66,54 +188,70 @@ template <typename From> struct simplify_type {
   // An accessor to get the real value...
   static SimpleType& getSimplifiedValue(From& Val) { return Val; }
 };
+/// @endcond 
 
+/// @cond INTERNAL
 // The core of the implementation of isa<X> is here; To and From should be
 // the names of classes.  This template can be specialized to customize the
 // implementation of isa<> without rewriting it from scratch.
 template <typename To, typename From, typename Enabler = void> struct isa_impl {
   static inline bool doit(const From& Val) { return To::classof(&Val); }
 };
+/// @endcond 
 
-/// Always allow upcasts, and perform no dynamic check for them.
+/// @cond INTERNAL
+// Always allow upcasts, and perform no dynamic check for them.
 template <typename To, typename From>
 struct isa_impl<
     To, From, typename std::enable_if<std::is_base_of<To, From>::value>::type> {
   static inline bool doit(const From&) { return true; }
 };
+/// @endcond 
 
+/// @cond INTERNAL
 template <typename To, typename From> struct isa_impl_cl {
   static inline bool doit(const From& Val) {
     return isa_impl<To, From>::doit(Val);
   }
 };
+/// @endcond 
 
+/// @cond  INTERNAL
 template <typename To, typename From> struct isa_impl_cl<To, const From> {
   static inline bool doit(const From& Val) {
     return isa_impl<To, From>::doit(Val);
   }
 };
+/// @endcond 
 
+/// @cond INTERNAL
 template <typename To, typename From> struct isa_impl_cl<To, From*> {
   static inline bool doit(const From* Val) {
     assert(Val && "isa<> used on a null pointer");
     return isa_impl<To, From>::doit(*Val);
   }
 };
+/// @endcond 
 
+/// @cond INTERNAL
 template <typename To, typename From> struct isa_impl_cl<To, From* const> {
   static inline bool doit(const From* Val) {
     assert(Val && "isa<> used on a null pointer");
     return isa_impl<To, From>::doit(*Val);
   }
 };
+/// @endcond 
 
+/// @cond INTERNAL
 template <typename To, typename From> struct isa_impl_cl<To, const From*> {
   static inline bool doit(const From* Val) {
     assert(Val && "isa<> used on a null pointer");
     return isa_impl<To, From>::doit(*Val);
   }
 };
+/// @endcond 
 
+/// @cond INTERNAL 
 template <typename To, typename From>
 struct isa_impl_cl<To, const From* const> {
   static inline bool doit(const From* Val) {
@@ -121,7 +259,9 @@ struct isa_impl_cl<To, const From* const> {
     return isa_impl<To, From>::doit(*Val);
   }
 };
+/// @endcond 
 
+/// @cond INTERNAL
 template <typename To, typename From, typename SimpleFrom>
 struct isa_impl_wrap {
   // When From != SimplifiedType, we can simplify the type some more by using
@@ -132,7 +272,9 @@ struct isa_impl_wrap {
         doit(simplify_type<const From>::getSimplifiedValue(Val));
   }
 };
+/// @endcond 
 
+/// @cond INTERNAL
 template <typename To, typename FromTy>
 struct isa_impl_wrap<To, FromTy, FromTy> {
   // When From == SimpleType, we are as simple as we are going to get.
@@ -140,6 +282,8 @@ struct isa_impl_wrap<To, FromTy, FromTy> {
     return isa_impl_cl<To, FromTy>::doit(Val);
   }
 };
+/// @endcond 
+
 
 // isa<X> - Return true if the parameter to the template is an instance of the
 // template type argument.  Used like this:
@@ -154,9 +298,11 @@ template <class X, class Y>[[nodiscard]] inline bool isa(const Y& Val) {
 //===----------------------------------------------------------------------===//
 //                          cast<x> Support Templates
 //===----------------------------------------------------------------------===//
-
+/// @cond INTERNAL
 template <class To, class From> struct cast_retty;
+/// @endcond
 
+/// @cond INTERNAL
 // Calculate what type the 'cast' function should return, based on a requested
 // type of To and a source type of From.
 template <class To, class From> struct cast_retty_impl {
@@ -177,7 +323,9 @@ template <class To, class From> struct cast_retty_impl<To, const From*> {
 template <class To, class From> struct cast_retty_impl<To, const From* const> {
   using ret_type = const To*; // Constant pointer arg case, return const Ty*
 };
+/// @endcond
 
+/// @cond INTERNAL
 template <class To, class From, class SimpleFrom> struct cast_retty_wrap {
   // When the simplified type and the from type are not the same, use the type
   // simplifier to reduce the type, then reuse cast_retty_impl to get the
@@ -194,7 +342,9 @@ template <class To, class From> struct cast_retty {
   using ret_type = typename cast_retty_wrap<
       To, From, typename simplify_type<From>::SimpleType>::ret_type;
 };
+/// @endcond
 
+/// @cond INTERNAL
 // Ensure the non-simple values are converted using the simplify_type template
 // that may be specialized by smart pointers...
 //
@@ -215,11 +365,14 @@ template <class To, class FromTy> struct cast_convert_val<To, FromTy, FromTy> {
     return Res2;
   }
 };
+/// @endcond
 
+/// @cond INTERNAL
 template <class X> struct is_simple_type {
   static const bool value =
       std::is_same<X, typename simplify_type<X>::SimpleType>::value;
 };
+/// @endcond
 
 // cast<X> - Return the argument parameter cast to the specified type.  This
 // casting operator asserts that the type is correct, so it does not return null


### PR DESCRIPTION
By request, documentation is collected at the top of this file to the
extent possible. The only comments added to the body of the file were
/// @cond ... /// @endcond pairs.

Two small fixes to .md files are piggybacking here.
- README.md : indentation fix
- CONTRIBUTING.md : change instructions for building documentation to
    specify use of cmake for both steps rather than cmake for first
    and make for second