### PR TITLE
Assorted tiny doc fixes

### DIFF
--- a/include/gtirb/Block.hpp
+++ b/include/gtirb/Block.hpp
@@ -131,7 +131,7 @@ struct GTIRB_EXPORT_API InstructionRef {
   /// \brief The block in which the instruction is located.
   NodeRef<Block> BlockRef;
 
-  /// \brief The offset of the instruction from the start of tyhe block, in
+  /// \brief The offset of the instruction from the start of the block, in
   /// bytes.
   uint64_t Offset;
 

--- a/include/gtirb/Casting.hpp
+++ b/include/gtirb/Casting.hpp
@@ -30,8 +30,8 @@
 /// that apply to gtirb::Node subclasses. For full details, see \ref casting.
 
 /// \defgroup casting Casting
-///
-/// gtirb::Node and its subclasses support custom casting machinery that
+/// 
+/// \brief gtirb::Node and its subclasses support custom casting machinery that
 /// allows for type checking, safer static casting, and safe dynamic
 /// casting without needing the overhead of a vtable or RTTI. File
 /// Casting.hpp defines the various operations that apply to gtirb::Node

--- a/include/gtirb/IR.hpp
+++ b/include/gtirb/IR.hpp
@@ -49,8 +49,8 @@ class Module;
 ///     imageByteMap [label="ImageByteMap" URL="\ref ImageByteMap"]
 ///     blocks [label="Block" URL="\ref Block"]
 ///     data [label="DataObject"  URL="\ref DataObject"]
-///     symbolicExpressions  [label="SymbolicExpression" URL="\ref
-///                            SymbolicExpression"]
+///     symbolicExpressions  [label="SymbolicExpression"
+///                           URL="\ref SymbolicExpression"]
 ///     sections [label="Section" URL="\ref Section"]
 ///     symbols [label="Symbol" URL="\ref Symbol"]
 ///     cfg [label="CFG" URL="\ref CFG"]


### PR DESCRIPTION
two typo fixes, one markup fix, one slightly expanded brief description.