### PR TITLE
Assorted small doxygen fixes/improvements

### DIFF
--- a/doc/doxy/Doxyfile.in
+++ b/doc/doxy/Doxyfile.in
@@ -769,7 +769,7 @@ WARN_FORMAT            = "$file:$line: $text"
 # messages should be written. If left blank the output is written to standard
 # error (stderr).
 
-WARN_LOGFILE           = 
+WARN_LOGFILE           = doxygen_warnings.txt
 
 #---------------------------------------------------------------------------
 # Configuration options related to the input files

--- a/include/gtirb/Block.hpp
+++ b/include/gtirb/Block.hpp
@@ -119,8 +119,11 @@ private:
 /// \ingroup CFG_GROUP
 /// \brief Create a new basic block and add it to the control-flow graph.
 ///
+/// \tparam Ts DOCFIXME
+///
 /// \param Cfg   The control-flow graph to modify
-/// \param Args  Forwarded to Block::Create
+/// \param C DOCFIXME
+/// \param Args  Forwarded to Block::Create()
 ///
 /// \return A descriptor which can be used to retrieve the \ref Block.
 template <class... Ts> Block* emplaceBlock(CFG& Cfg, Context& C, Ts&&... Args) {

--- a/include/gtirb/CFG.hpp
+++ b/include/gtirb/CFG.hpp
@@ -105,6 +105,7 @@ using block_iterator = block_iter_base<Block, CFG>;
 /// \brief DOCFIXME
 using const_block_iterator = block_iter_base<const Block, const CFG>;
 
+/// \ingroup CFG_GROUP
 /// \brief Create a new edge between two blocks.
 ///
 /// \param Cfg   The graph to modify.

--- a/include/gtirb/Context.hpp
+++ b/include/gtirb/Context.hpp
@@ -26,10 +26,11 @@
 
 namespace gtirb {
 
-/// \relates Node
-/// \relatesalso Context
 /// \brief Represents a universally unique identifier used to identify Node
 /// objects across serialization boundaries.
+///
+/// \see Node
+/// \see Context 
 using UUID = boost::uuids::uuid;
 
 class Node;

--- a/include/gtirb/Module.hpp
+++ b/include/gtirb/Module.hpp
@@ -255,7 +255,7 @@ public:
 
   /// \brief Finds symbols by name
   ///
-  /// \param X The address to look up.
+  /// \param N The address to look up.
   ///
   /// \return An iterator to the found object, or \ref symbol_end() if not
   /// found.
@@ -265,7 +265,7 @@ public:
 
   /// \brief Finds symbols by name
   ///
-  /// \param X The address to look up.
+  /// \param N The address to look up.
   ///
   /// \return An iterator to the found object, or \ref symbol_end() if not
   /// found.

--- a/include/gtirb/Symbol.hpp
+++ b/include/gtirb/Symbol.hpp
@@ -163,7 +163,22 @@ public:
   using supported_referent_types = TypeList<Block, DataObject>;
 
   /// \brief Visits the symbol's referent, if one is present, by concrete
-  /// referent type. For example:
+  /// referent type. 
+  ///
+  /// \tparam Callable  A callable function type. This type must be able to be
+  /// called with a pointer to all of the types listed in \ref
+  /// supported_referent_types. All overloaded functions must have a common,
+  /// compatible return type.
+  ///
+  /// \param Visitor  A callable object that will be called with a nonnull
+  /// symbol referent.
+  ///
+  /// \return The common type of each of the return types in the \p Callable
+  /// overload set. Notionally returns:
+  /// std::common_type_t<Overload1(Ty1), Overload2(Ty2), ...>
+  /// which can be void.
+  ///
+  /// For example:
   ///
   /// \code
   /// struct Visitor {
@@ -177,22 +192,9 @@ public:
   /// Symbol* SymN = Symbol::Create(Ctx);
   ///
   /// SymB->visit(Visitor{}); // Will call Visitor::operator()(Block*);
-  /// SymD->visit(Visitor{}); // Will call Visitor::operator()(DatObject*);
+  /// SymD->visit(Visitor{}); // Will call Visitor::operator()(DataObject*);
   /// SymN->visit(Visitor{}); // Will not call either overload
   /// \endcode
-  ///
-  /// \tparam Callable  A callable function type. This type must be able to be
-  /// called with a pointer to all of the types listed in \ref
-  /// supported_referent_types. All overloaded functions must have a common,
-  /// compatible return type.
-  ///
-  /// \param Visitor  A callable object that will be called with a nonnull
-  /// symbol referent.
-  ///
-  /// \return The common type of each of the return types in the Callable
-  /// overload set. Notionally returns:
-  /// std::common_type_t<Overload1(Ty1), Overload2(Ty2), ...>
-  /// which can be void.
   template <typename Callable> auto visit(Callable&& Visitor) const {
     return visit_impl(std::forward<Callable>(Visitor),
                       std::decay_t<supported_referent_types>{});
@@ -297,8 +299,8 @@ public:
   ///
   /// \tparam NodeTy A Node type of a supported referent.
   ///
-  /// \return The data, dynamically typed as the given NodeTy, or null if there
-  /// is no referent of that type.
+  /// \return The data, dynamically typed as the given \p NodeTy, or
+  /// null if there is no referent of that type.
   template <typename NodeTy> NodeTy* getReferent() {
     return dyn_cast_or_null<NodeTy>(Referent);
   }
@@ -307,8 +309,8 @@ public:
   ///
   /// \tparam NodeTy A Node type of a supported referent.
   ///
-  /// \return The data, dynamically typed as the given NodeTy, or null if there
-  /// is no referent of that type.
+  /// \return The data, dynamically typed as the given \p NodeTy, or
+  /// null if there is no referent of that type.
   template <typename NodeTy> const NodeTy* getReferent() const {
     return dyn_cast_or_null<NodeTy>(Referent);
   }

--- a/include/gtirb/SymbolicExpression.hpp
+++ b/include/gtirb/SymbolicExpression.hpp
@@ -35,8 +35,9 @@ class Context;
 /// \brief DOCFIXME
 /// @{
 
-/// \brief Represents a symbolic operand of the form "StackVar + Const".
-/// DOCFIXME[word in terms of the field names]
+/// \brief Represents a 
+/// \ref SYMBOLIC_EXPRESSION_GROUP "symbolic operand" of the form
+/// "StackVar + Const".  DOCFIXME[word in terms of the field names]
 struct SymStackConst {
   // TODO: What's this?
   bool Negate;      ///< DOCFIXME
@@ -45,16 +46,18 @@ struct SymStackConst {
   Symbol* Sym;      ///< DOCFIXME
 };
 
-/// \brief Represents a symbolic operand of the form "Addr + Const".
-/// DOCFIXME[word in terms of the field names]
+/// \brief Represents a 
+/// \ref SYMBOLIC_EXPRESSION_GROUP "symbolic operand" of the form
+/// "Addr + Const".  DOCFIXME[word in terms of the field names]
 struct SymAddrConst {
   int64_t Displacement; ///< DOCFIXME
   Symbol* Sym;          ///< DOCFIXME
 };
 
-/// \brief Represents a symbolic operand of the form "(Addr - Addr) /
-/// Scale + Offset"
-/// DOCFIXME[word in terms of the field names]
+/// \brief Represents a 
+/// \ref SYMBOLIC_EXPRESSION_GROUP "symbolic operand" of the form
+/// "(Addr - Addr) / Scale + Offset" DOCFIXME[word in terms of the
+/// field names]
 struct SymAddrAddr {
   int64_t Scale;  ///< DOCFIXME
   int64_t Offset; ///< DOCFIXME
@@ -62,7 +65,7 @@ struct SymAddrAddr {
   Symbol* Sym2;   ///< DOCFIXME
 };
 
-/// \brief DOCFIXME
+/// \brief DOCFIXME A \ref SYMBOLIC_EXPRESSION_GROUP "symbolic expression".
 using SymbolicExpression =
     std::variant<SymStackConst, SymAddrConst, SymAddrAddr>;
 

--- a/include/gtirb/Table.hpp
+++ b/include/gtirb/Table.hpp
@@ -342,7 +342,7 @@ public:
 ///   - all integral types
 ///   - Addr
 ///   - InstructionRef
-///   - UUID
+///   - \ref UUID
 ///   - sequential containers
 ///   - mapping containers
 ///   - std::tuple
@@ -425,13 +425,13 @@ public:
   ///
   /// \param <unnamed>   Not used.
   /// \param Message     The protobuf message from which to deserialize.
-  /// \param[out] Table  The Table to initialize.
+  /// \param[out] result  The Table to initialize.
   GTIRB_EXPORT_API friend void fromProtobuf(Context&, Table& result,
                                             const proto::Table& Message);
 
   /// \brief Serialize into a protobuf message.
   ///
-  /// \param      Table     The Table to serialize.
+  /// \param <unnamed>     The Table to serialize.
   ///
   /// \return A protobuf message representing the table.
   GTIRB_EXPORT_API friend proto::Table toProtobuf(const Table&);


### PR DESCRIPTION
You can't use \relates with a typedef, which is stupid if you ask me but there you have it,