### PR TITLE
Final pass doxygen fixes for upcoming deliverable

### DIFF
--- a/include/gtirb/Block.hpp
+++ b/include/gtirb/Block.hpp
@@ -24,7 +24,9 @@
 #include <vector>
 
 /// \file Block.hpp
+/// \ingroup CFG_GROUP
 /// \brief Classes gtirb::Block and gtirb::InstructionRef.
+/// \see CFG_GROUP
 
 namespace proto {
 class InstructionRef;
@@ -89,6 +91,7 @@ public:
   /// \return The exit kind.
   Exit getExitKind() const { return ExitKind; }
 
+  /// \brief The protobuf message type used for serializing Block.
   using MessageType = proto::Block;
 
   /// \brief Serialize into a protobuf message.

--- a/include/gtirb/ByteMap.hpp
+++ b/include/gtirb/ByteMap.hpp
@@ -41,6 +41,7 @@ class ImageByteMap;
 ///
 /// \brief Holds the bytes of the loaded image of the binary.
 class GTIRB_EXPORT_API ByteMap {
+  /// \copybrief gtirb::ImageByteMap
   friend class ImageByteMap;
   bool willOverlapRegion(Addr A, size_t Bytes) const;
 

--- a/include/gtirb/CFG.hpp
+++ b/include/gtirb/CFG.hpp
@@ -24,8 +24,11 @@
 #include <variant>
 
 /// \file CFG.hpp
-/// \brief Typedefs and operations for interprocedural
-/// \ref CFG_GROUP "control flow graphs" (CFGs).
+/// \ingroup CFG_GROUP
+/// \brief Types and operations for interprocedural control flow
+/// graphs (CFGs).
+///
+/// \see CFG_GROUP
 
 namespace proto {
 class CFG;
@@ -34,14 +37,14 @@ class CFG;
 namespace gtirb {
 class Block;
 
-/// \defgroup CFG_GROUP CFGs
+/// \defgroup CFG_GROUP Control Flow Graphs (CFGs)
 /// \brief Interprocedural control flow graph, with vertices of type
 /// \ref Block.
 ///
 /// @{ @}
 
 /// \ingroup CFG_GROUP
-/// \brief A label on a CFG edge.
+/// \brief A label on a \ref CFG edge.
 ///
 /// Boolean labels are used in the case of a conditional branch or call.
 /// A true label designates the non-local edge (e.g. when the condition is
@@ -95,11 +98,11 @@ private:
 /// @endcond
 
 /// \ingroup CFG_GROUP
-/// \brief Iterator over \ref Block "Blocks".
+/// \brief Iterator over blocks (\ref Block).
 using block_iterator = block_iter_base<Block, CFG>;
 
 /// \ingroup CFG_GROUP
-/// \brief Constant iterator over \ref Block "Blocks".
+/// \brief Constant iterator over blocks (\ref Block).
 using const_block_iterator = block_iter_base<const Block, const CFG>;
 
 /// \ingroup CFG_GROUP
@@ -133,15 +136,16 @@ GTIRB_EXPORT_API boost::iterator_range<const_block_iterator>
 blocks(const CFG& cfg);
 
 /// \ingroup CFG_GROUP
-/// \brief Serialize a CFG into a protobuf message.
+/// \brief Serialize a \ref CFG into a protobuf message.
 ///
 /// \param Cfg   The CFG to serialize.
 ///
-/// \return A protobuf message representing the CFG and its component Blocks.
+/// \return A protobuf message representing the \ref CFG and its
+/// component blocks (\ref Block).
 GTIRB_EXPORT_API proto::CFG toProtobuf(const CFG& Cfg);
 
 /// \ingroup CFG_GROUP
-/// \brief Initialize a CFG from a protobuf message.
+/// \brief Initialize a \ref CFG from a protobuf message.
 ///
 /// \param      C        The Context in which the deserialized CFG will be held.
 /// \param      Message  The protobuf message from which to deserialize.

--- a/include/gtirb/Casting.hpp
+++ b/include/gtirb/Casting.hpp
@@ -25,18 +25,21 @@
 #include <type_traits>
 
 /// \file Casting.hpp
+/// \ingroup casting
+/// \brief The various casting and type checking operations that apply
+/// to gtirb::Node subclasses.
 ///
-/// This file defines the various casting and type checking operations
-/// that apply to gtirb::Node subclasses. For full details, see \ref casting.
+/// \see \ref casting.
 
 /// \defgroup casting Casting
 ///
-/// \brief gtirb::Node and its subclasses support custom casting machinery that
-/// allows for type checking, safer static casting, and safe dynamic
-/// casting without needing the overhead of a vtable or RTTI. File
-/// Casting.hpp defines the various operations that apply to gtirb::Node
-/// subclasses.
+/// \brief \ref gtirb::Node "Node" and its subclasses support custom casting
+/// machinery that allows for type checking, safer static casting, and
+/// safe dynamic casting without needing the overhead of a vtable or
+/// RTTI.
 ///
+/// File Casting.hpp defines the various operations that apply
+/// to \ref gtirb::Node "Node" subclasses.
 /// - \ref ISA "isa<Ty>" Performs a type check.
 /// - \ref CAST "cast<Ty>" Returns the given argument cast to the
 ///   specified type;  the argument cannot be null.
@@ -50,8 +53,9 @@
 ///   operation fails because the types do not match; the argument can
 ///   be null.
 ///
+/// \section casting_operations Casting Operations
 ///
-/// \section ISA isa<Ty>
+/// \subsection ISA isa<Ty>
 ///
 /// Perform a type check.
 ///
@@ -68,7 +72,7 @@
 /// \endcode
 ///
 ///
-/// \section  CAST cast<Ty>
+/// \subsection CAST cast<Ty>
 ///
 /// Cast to the specified type; the argument cannot be null.
 ///
@@ -89,7 +93,7 @@
 /// \endcode
 ///
 ///
-/// \section CAST_OR_NULL cast_or_null<Ty>
+/// \subsection CAST_OR_NULL cast_or_null<Ty>
 ///
 /// Cast to the specified type; the argument can be null.
 ///
@@ -110,7 +114,7 @@
 /// \endcode
 ///
 ///
-/// \section  DYN_CAST dyn_cast<Ty>
+/// \subsection  DYN_CAST dyn_cast<Ty>
 ///
 /// Dynamic cast to the specified type; the argument cannot be null.
 ///
@@ -131,7 +135,7 @@
 /// \endcode
 ///
 ///
-/// \section DYN_CAST_OR_NULL dyn_cast_or_null<Ty>
+/// \subsection DYN_CAST_OR_NULL dyn_cast_or_null<Ty>
 ///
 /// Cast to the specified type; the argument can be null.
 ///

--- a/include/gtirb/Context.hpp
+++ b/include/gtirb/Context.hpp
@@ -53,6 +53,8 @@ class GTIRB_EXPORT_API Context {
   mutable BumpPtrAllocator Allocator;
 
   std::map<UUID, Node*> UuidMap;
+
+  /// \copybrief gtirb::Node
   friend class Node;
 
   void registerNode(const UUID& ID, Node* N) { UuidMap[ID] = N; }

--- a/include/gtirb/IR.hpp
+++ b/include/gtirb/IR.hpp
@@ -26,7 +26,9 @@
 #include <vector>
 
 /// \file IR.hpp
+/// \ingroup TABLE_GROUP
 /// \brief Class gtirb::IR.
+/// \see TABLE_GROUP
 
 namespace proto {
 class IR;

--- a/include/gtirb/Module.hpp
+++ b/include/gtirb/Module.hpp
@@ -178,63 +178,66 @@ public:
   /// A Module can have exactly one ImageByteMap child.
   const gtirb::ImageByteMap& getImageByteMap() const;
 
-  /// \brief Iterator over \ref Symbol "Symbols".
+  /// \name Symbol-Related Public Types and Functions
+  /// @{
+
+  /// \brief Iterator over symbols (\ref Symbol).
   using symbol_iterator =
       boost::transform_iterator<SymSetTransform<SymbolSet::iterator>,
                                 SymbolSet::iterator, Symbol&>;
-  /// \brief Range of \ref Symbol "Symbols".
+  /// \brief Range of symbols (\ref Symbol).
   using symbol_range = boost::iterator_range<symbol_iterator>;
-  /// \brief Constant iterator over \ref Symbol "Symbols".
+  /// \brief Constant iterator over symbols (\ref Symbol).
   using const_symbol_iterator =
       boost::transform_iterator<SymSetTransform<SymbolSet::const_iterator>,
                                 SymbolSet::const_iterator, const Symbol&>;
-  /// \brief Constant range of \ref Symbol "Symbols".
+  /// \brief Constant range of symbols (\ref Symbol).
   using const_symbol_range = boost::iterator_range<const_symbol_iterator>;
 
-  /// \brief Iterator over \ref Symbol "Symbols".
+  /// \brief Iterator over symbols (\ref Symbol).
   using symbol_addr_iterator =
       boost::transform_iterator<SymSetTransform<SymbolAddrMap::iterator>,
                                 SymbolAddrMap::iterator, Symbol&>;
-  /// \brief Range of \ref Symbol "Symbols".
+  /// \brief Range of symbols (\ref Symbol).
   using symbol_addr_range = boost::iterator_range<symbol_addr_iterator>;
-  /// \brief Constant iterator over \ref Symbol "Symbols".
+  /// \brief Constant iterator over symbols (\ref Symbol).
   using const_symbol_addr_iterator =
       boost::transform_iterator<SymSetTransform<SymbolAddrMap::const_iterator>,
                                 SymbolAddrMap::const_iterator, const Symbol&>;
-  /// \brief Constant range of \ref Symbol "Symbols".
+  /// \brief Constant range of symbols (\ref Symbol).
   using const_symbol_addr_range =
       boost::iterator_range<const_symbol_addr_iterator>;
 
-  /// \brief Returns an iterator to the first Symbol.
+  /// \brief Return an iterator to the first Symbol.
   symbol_iterator symbol_begin() { return symbol_iterator(Symbols.begin()); }
-  /// \brief Returns a constant iterator to the first Symbol.
+  /// \brief Return a constant iterator to the first Symbol.
   const_symbol_iterator symbol_begin() const {
     return const_symbol_iterator(Symbols.begin());
   }
-  /// \brief Returns an iterator to the element following the last Symbol.
+  /// \brief Return an iterator to the element following the last Symbol.
   symbol_iterator symbol_end() { return symbol_iterator(Symbols.end()); }
-  /// \brief Returns a constant iterator to the element following the last
+  /// \brief Return a constant iterator to the element following the last
   /// Symbol.
   const_symbol_iterator symbol_end() const {
     return const_symbol_iterator(Symbols.end());
   }
-  /// \brief Returns a range of the \ref Symbol "Symbols".
+  /// \brief Return a range of the symbols (\ref Symbol).
   symbol_range symbols() {
     return boost::make_iterator_range(symbol_begin(), symbol_end());
   }
-  /// \brief Returns a constant range of the \ref Symbol "Symbols".
+  /// \brief Return a constant range of the symbols (\ref Symbol).
   const_symbol_range symbols() const {
     return boost::make_iterator_range(symbol_begin(), symbol_end());
   }
 
-  /// \brief Adds a single symbol to the module.
+  /// \brief Add a single symbol to the module.
   ///
   /// \param S The Symbol object to add.
   ///
   /// \return void
   void addSymbol(Symbol* S) { addSymbol({S}); }
 
-  /// \brief Adds one or more symbols to the module.
+  /// \brief Add one or more symbols to the module.
   ///
   /// \param Ss The list of Symbol objects to add.
   ///
@@ -248,7 +251,7 @@ public:
     }
   }
 
-  /// \brief Finds symbols by name
+  /// \brief Find symbols by name
   ///
   /// \param N The address to look up.
   ///
@@ -258,7 +261,7 @@ public:
     return symbol_iterator(Symbols.find(N));
   }
 
-  /// \brief Finds symbols by name
+  /// \brief Find symbols by name
   ///
   /// \param N The address to look up.
   ///
@@ -268,7 +271,7 @@ public:
     return const_symbol_iterator(Symbols.find(N));
   }
 
-  /// \brief Finds symbols by address.
+  /// \brief Find symbols by address.
   ///
   /// \param X The address to look up.
   ///
@@ -280,7 +283,7 @@ public:
                                       symbol_addr_iterator(Found.second));
   }
 
-  /// \brief Finds symbols by address.
+  /// \brief Find symbols by address.
   ///
   /// \param X The address to look up.
   ///
@@ -291,6 +294,8 @@ public:
     return boost::make_iterator_range(const_symbol_addr_iterator(Found.first),
                                       const_symbol_addr_iterator(Found.second));
   }
+  /// @}
+  // (end group of symbol-related type aliases and functions)
 
   /// \brief Set the module name.
   ///
@@ -315,52 +320,55 @@ public:
   /// \return The associated CFG.
   CFG& getCFG() { return Cfg; }
 
-  /// \brief Iterator over \ref DataObject "DataObjects".
+  /// \name DataObject-Related Public Types and Functions
+  /// @{
+
+  /// \brief Iterator over data objects (\ref DataObject).
   using data_object_iterator =
       boost::transform_iterator<SymSetTransform<DataSet::iterator>,
                                 DataSet::iterator, DataObject&>;
-  /// \brief Range of \ref DataObject "DataObjects".
+  /// \brief Range of data objects (\ref DataObject).
   using data_object_range = boost::iterator_range<data_object_iterator>;
-  /// \brief Constant iterator over \ref DataObject "DataObjects".
+  /// \brief Constant iterator over data objects (\ref DataObject).
   using const_data_object_iterator =
       boost::transform_iterator<SymSetTransform<DataSet::const_iterator>,
                                 DataSet::const_iterator, const DataObject&>;
-  /// \brief Constant range of \ref DataObject "DataObjects".
+  /// \brief Constant range of data objects (\ref DataObject).
   using const_data_object_range =
       boost::iterator_range<const_data_object_iterator>;
 
-  /// \brief Returns an iterator to the first DataObject.
+  /// \brief Return an iterator to the first DataObject.
   data_object_iterator data_begin() {
     return data_object_iterator(Data.begin());
   }
-  /// \brief Returns a constant iterator to the first DataObject.
+  /// \brief Return a constant iterator to the first DataObject.
   const_data_object_iterator data_begin() const {
     return const_data_object_iterator(Data.begin());
   }
-  /// \brief Returns an iterator to the element following the last DataObject.
+  /// \brief Return an iterator to the element following the last DataObject.
   data_object_iterator data_end() { return data_object_iterator(Data.end()); }
-  /// \brief Returns a constant iterator to the element following the last
+  /// \brief Return a constant iterator to the element following the last
   /// DataObject.
   const_data_object_iterator data_end() const {
     return const_data_object_iterator(Data.end());
   }
-  /// \brief Returns a range of the \ref DataObject "DataObjects".
+  /// \brief Return a range of the data objects (\ref DataObject).
   data_object_range data() {
     return boost::make_iterator_range(data_begin(), data_end());
   }
-  /// \brief Returns a constant range of the \ref DataObject "DataObjects".
+  /// \brief Return a constant range of the data objects (\ref DataObject).
   const_data_object_range data() const {
     return boost::make_iterator_range(data_begin(), data_end());
   }
 
-  /// \brief Adds a single data object to the module.
+  /// \brief Add a single data object to the module.
   ///
   /// \param DO The DataObject object to add.
   ///
   /// \return void
   void addData(DataObject* DO) { addData({DO}); }
 
-  /// \brief Adds one or more data objects to the module.
+  /// \brief Add one or more data objects to the module.
   ///
   /// \param Ds The list of DataObject objects to add.
   ///
@@ -370,7 +378,7 @@ public:
       Data.emplace(D->getAddress(), D);
   }
 
-  /// \brief Finds DataObjects by address.
+  /// \brief Find a DataObject by address.
   ///
   /// \param X The address to look up.
   ///
@@ -379,7 +387,7 @@ public:
     return data_object_iterator(Data.find(X));
   }
 
-  /// \brief Finds DataObjects by address.
+  /// \brief Find a DataObject by address.
   ///
   /// \param X The address to look up.
   ///
@@ -387,52 +395,57 @@ public:
   const_data_object_iterator findData(Addr X) const {
     return const_data_object_iterator(Data.find(X));
   }
+  /// @}
+  // (end group of DataObject-related types and functions)
 
-  /// \brief Iterator over \ref Section "Sections".
+  /// \name Section-Related Public Types and Functions
+  /// @{
+
+  /// \brief Iterator over sections (\ref Section).
   using section_iterator =
       boost::transform_iterator<SymSetTransform<SectionSet::iterator>,
                                 SectionSet::iterator, Section&>;
-  /// \brief Range of \ref Section "Sections".
+  /// \brief Range of sections (\ref Section).
   using section_range = boost::iterator_range<section_iterator>;
-  /// \brief Constant iterator over \ref Section "Sections".
+  /// \brief Constant iterator over sections (\ref Section).
   using const_section_iterator =
       boost::transform_iterator<SymSetTransform<SectionSet::const_iterator>,
                                 SectionSet::const_iterator, const Section&>;
-  /// \brief Constant range of \ref Section "Sections".
+  /// \brief Constant range of sections (\ref Section).
   using const_section_range = boost::iterator_range<const_section_iterator>;
 
-  /// \brief Returns an iterator to the first Section.
+  /// \brief Return an iterator to the first Section.
   section_iterator section_begin() {
     return section_iterator(Sections.begin());
   }
-  /// \brief Returns a constant iterator to the first Section.
+  /// \brief Return a constant iterator to the first Section.
   const_section_iterator section_begin() const {
     return const_section_iterator(Sections.begin());
   }
-  /// \brief Returns an iterator to the element following the last Section.
+  /// \brief Return an iterator to the element following the last Section.
   section_iterator section_end() { return section_iterator(Sections.end()); }
-  /// \brief Returns a constant iterator to the element following the last
+  /// \brief Return a constant iterator to the element following the last
   /// Section.
   const_section_iterator section_end() const {
     return const_section_iterator(Sections.end());
   }
-  /// \brief Returns a range of the \ref Section "Sections".
+  /// \brief Return a range of the sections (\ref Section).
   section_range sections() {
     return boost::make_iterator_range(section_begin(), section_end());
   }
-  /// \brief Returns a constant range of the \ref Section "Sections".
+  /// \brief Return a constant range of the sections (\ref Section).
   const_section_range sections() const {
     return boost::make_iterator_range(section_begin(), section_end());
   }
 
-  /// \brief Adds a single section object to the module.
+  /// \brief Add a single Section object to the module.
   ///
   /// \param S The Section object to add.
   ///
   /// \return void
   void addSection(Section* S) { addSection({S}); }
 
-  /// \brief Adds one or more section objects to the module.
+  /// \brief Add one or more section objects to the module.
   ///
   /// \param Ss The list of Section objects to add.
   ///
@@ -442,7 +455,7 @@ public:
       Sections.emplace(S->getAddress(), S);
   }
 
-  /// \brief Finds Sections by address.
+  /// \brief Find a Section by address.
   ///
   /// \param X The address to look up.
   ///
@@ -452,7 +465,7 @@ public:
     return section_iterator(Sections.find(X));
   }
 
-  /// \brief Finds Sections by address.
+  /// \brief Find a Section by address.
   ///
   /// \param X The address to look up.
   ///
@@ -461,54 +474,60 @@ public:
   const_section_iterator findSection(Addr X) const {
     return const_section_iterator(Sections.find(X));
   }
+  /// @}
+  // (end group of Section-related types and functions)
 
-  /// \brief Iterator over \ref SymbolicExpression "SymbolicExpressions".
+  /// \name SymbolicExpression-Related Public Types and Functions
+  /// @{
+
+  /// \brief Iterator over symbolic expressions (\ref SymbolicExpression).
   using symbolic_expr_iterator = boost::transform_iterator<
       SymExprSetTransform<SymbolicExpressionSet::iterator>,
       SymbolicExpressionSet::iterator, SymbolicExpression&>;
-  /// \brief Range of \ref SymbolicExpression "SymbolicExpressions".
+  /// \brief Range of symbolic expressions (\ref SymbolicExpression).
   using symbolic_expr_range = boost::iterator_range<symbolic_expr_iterator>;
-  /// \brief Constant iterator over
-  /// \ref SymbolicExpression "SymbolicExpressions".
+  /// \brief Constant iterator over symbolic expressions
+  /// (\ref SymbolicExpression).
   using const_symbolic_expr_iterator = boost::transform_iterator<
       SymExprSetTransform<SymbolicExpressionSet::const_iterator>,
       SymbolicExpressionSet::const_iterator, const SymbolicExpression&>;
-  /// \brief Constant range of \ref SymbolicExpression "SymbolicExpressions".
+  /// \brief Constant range of symbolic expressions (\ref SymbolicExpression).
   using const_symbolic_expr_range =
       boost::iterator_range<const_symbolic_expr_iterator>;
 
-  /// \brief Returns an iterator to the first SymbolicExpression.
+  /// \brief Return an iterator to the first \ref SymbolicExpression.
   symbolic_expr_iterator symbolic_expr_begin() {
     return symbolic_expr_iterator(SymbolicOperands.begin());
   }
-  /// \brief Returns a constant iterator to the first SymbolicExpression.
+  /// \brief Return a constant iterator to the first \ref SymbolicExpression.
   const_symbolic_expr_iterator symbolic_expr_begin() const {
     return const_symbolic_expr_iterator(SymbolicOperands.begin());
   }
-  /// \brief Returns an iterator to the element following the last
-  /// SymbolicExpression.
+  /// \brief Return an iterator to the element following the last
+  /// \ref SymbolicExpression.
   symbolic_expr_iterator symbolic_expr_end() {
     return symbolic_expr_iterator(SymbolicOperands.end());
   }
-  /// \brief Returns a constant iterator to the element following the last
-  /// SymbolicExpression.
+  /// \brief Return a constant iterator to the element following the last
+  /// \ref SymbolicExpression.
   const_symbolic_expr_iterator symbolic_expr_end() const {
     return const_symbolic_expr_iterator(SymbolicOperands.end());
   }
-  /// \brief Returns a range of the
-  /// \ref SymbolicExpression "SymbolicExpressions".
+  /// \brief Return a range of the symbolic expressions
+  /// (\ref SymbolicExpression).
   symbolic_expr_range symbolic_exprs() {
     return boost::make_iterator_range(symbolic_expr_begin(),
                                       symbolic_expr_end());
   }
-  /// \brief Returns a constant range of the
-  /// \ref SymbolicExpression "SymbolicExpressions".
+  /// \brief Return a constant range of the symbolic expressions
+  /// (\ref SymbolicExpression).
   const_symbolic_expr_range symbolic_exprs() const {
     return boost::make_iterator_range(symbolic_expr_begin(),
                                       symbolic_expr_end());
   }
 
-  /// \brief Finds symbolic expressions by address.
+  /// \brief Find symbolic expressions (\ref SymbolicExpression) by
+  /// address.
   ///
   /// \param X The address to look up.
   ///
@@ -518,7 +537,8 @@ public:
     return symbolic_expr_iterator(SymbolicOperands.find(X));
   }
 
-  /// \brief Finds symbolic expressions by address.
+  /// \brief Find symbolic expressions (\ref SymbolicExpression) by
+  /// address.
   ///
   /// \param X The address to look up.
   ///
@@ -529,7 +549,8 @@ public:
     return const_symbolic_expr_iterator(SymbolicOperands.find(X));
   }
 
-  /// \brief Adds a symbolic expression to the module.
+  /// \brief Add a symbolic expression (\ref SymbolicExpression) to
+  /// the module.
   ///
   /// \param X  The address of the symbolic expression.
   /// \param SE The SymbolicExpression object to add.
@@ -538,6 +559,8 @@ public:
   void addSymbolicExpression(Addr X, const SymbolicExpression& SE) {
     SymbolicOperands.emplace(X, SE);
   }
+  /// @}
+  // (end group of SymbolicExpression-related type aliases and methods)
 
   /// \brief The protobuf message type used for serializing Module.
   using MessageType = proto::Module;

--- a/include/gtirb/Node.hpp
+++ b/include/gtirb/Node.hpp
@@ -32,8 +32,8 @@ class Node;
 /// \brief Represents the base of the Node class hierarchy.
 ///
 /// Objects of Node types can be converted into more specific types by
-/// using the casting machinery from Casting.hpp. You can use
-/// static_cast<>() and reinterpret_cast<>(), but cast<>() and
+/// using the \ref casting "casting machinery" from Casting.hpp. You
+/// can use static_cast<>() and reinterpret_cast<>(), but cast<>() and
 /// dyn_cast<>() are safer alternatives. You cannot use dynamic_cast<>
 /// to cast Node objects.
 class GTIRB_EXPORT_API Node {

--- a/include/gtirb/SymbolicExpression.hpp
+++ b/include/gtirb/SymbolicExpression.hpp
@@ -23,8 +23,10 @@
 #include <variant>
 
 /// \file SymbolicExpression.hpp
-/// \brief \ref SYMBOLIC_EXPRESSION_GROUP.
-
+/// \ingroup SYMBOLIC_EXPRESSION_GROUP
+/// \brief Types and operations for symbolic expressions.
+///
+/// \see \ref SYMBOLIC_EXPRESSION_GROUP.
 namespace proto {
 class SymbolicExpression;
 }

--- a/include/gtirb/Table.hpp
+++ b/include/gtirb/Table.hpp
@@ -28,7 +28,9 @@
 #include <vector>
 
 /// \file Table.hpp
-/// \brief  Definitions and functions for \ref TABLE_GROUP.
+/// \ingroup TABLE_GROUP
+/// \brief  Types and operations for tables.
+/// \see TABLE_GROUP
 
 namespace proto {
 class Table;
@@ -38,9 +40,9 @@ namespace gtirb {
 class Context;
 
 /// \defgroup TABLE_GROUP Tables
-/// \brief \ref Table "Tables" can be attached to the \ref IR to store
+/// \brief Tables (\ref Table)  can be attached to the \ref IR to store
 /// additional client-specific data in a portable way.
-
+///
 /// Tables can store the following types:
 ///   - all integral types
 ///   - Addr
@@ -50,26 +52,26 @@ class Context;
 ///   - mapping containers
 ///   - std::tuple
 ///
-/// \par Supporting Additional Types
+/// ### Supporting Additional Types
+///
 /// Support for additional containers can be added by specializing \ref
 /// is_sequence or \ref is_mapping. Once serialized, the table does not
 /// depend on any specific container type, and its contents can be
 /// deserialized into different containers of the same kind (e.g. \c std::list
 /// to \c std::vector).
 ///
-/// \par
 /// Support for other types can be added by specializing \ref table_traits to
 /// provide serialization functions. However, tables containing these types
 /// will not be accessible to other clients which are not compiled with
 /// support for those types. It is preferable to store data using the basic
 /// table types whenever possible, in order to maximize interoperability.
 ///
-/// \par Serialization Format
+/// ### Serialization Format
+///
 /// Tables are serialized by packing their contents into a byte array, which
 /// is stored in a protobuf message along with a string which identifies the
 /// type in a portable fashion.
-
-/// \par
+///
 /// Fixed-size types such as integers, Addr, etc are packed by swapping their
 /// bytes to little-endian order and writing them directly to the byte
 /// array. Containers first write out the number of elements (as a uint64_t),
@@ -80,7 +82,10 @@ class Context;
 
 /// \struct is_sequence
 ///
-/// \brief Trait class that identifies whether T is a sequential container type.
+/// \brief Trait class that identifies whether T is a sequential
+/// container type.
+///
+/// \see TABLE_GROUP
 template <class T> struct is_sequence : std::false_type {};
 
 /// @cond INTERNAL
@@ -91,6 +96,8 @@ template <class T> struct is_sequence<std::list<T>> : std::true_type {};
 /// \struct is_mapping
 ///
 /// \brief Trait class that identifies whether T is a mapping container type.
+///
+/// \see TABLE_GROUP
 template <class T> struct is_mapping : std::false_type {};
 /// @cond INTERNAL
 template <class T, class U>
@@ -111,6 +118,8 @@ using from_iterator = std::string::const_iterator;
 ///
 /// \brief Provides type information and serialization functions
 /// for types which can be stored in tables.
+///
+/// \see TABLE_GROUP
 template <class T, class Enable = void> struct table_traits {
   /// \brief  Serialize an object to a sequence of bytes.
   ///
@@ -374,9 +383,10 @@ public:
 };
 /// @endcond
 
-/// \brief A generic \ref TABLE_GROUP "table" for storing additional
-/// client-specific data.
+/// \brief A generic table for storing additional client-specific
+/// data.
 ///
+/// \see \ref TABLE_GROUP
 
 class Table {
 public:
@@ -404,8 +414,8 @@ public:
   ///
   /// \tparam T  The expected type of the contents.
   ///
-  /// \returns  If Table contains an object of type T, return a pointer to
-  ///           it. Otherwise return nullptr.
+  /// \returns If the table contains an object of type T, return a
+  /// pointer to it. Otherwise return nullptr.
   //
   template <typename T> T* get() {
     if (!this->RawBytes.empty()) {


### PR DESCRIPTION
Assorted small markup fixes

Remove various empty comments.
- In some cases, copy a parallel comment.
- For 'friend' entries, tell Doxygen to copy the brief description of
  the friend in question.

Make relevant files members of the four "module" groups.
Reformat the Casting module documentation a bit for visual appeal.

Add in some explicit links.

Generally change references of the form '\ref TYPENAME "TYPENAMEs"' to
'TYPENAMEs (\ref TYPENAME)' or '(other expression of type name)s (\ref
TYPENAME) so that users can't mistakenly conclude that TYPENAMEs is the
name of a type.

Add member groups to class Module by request of NW.

*** NB this commit does NOT add any DOCFIXMES. ***