### PR TITLE
Call node destructors when freeing the Context.

### DIFF
--- a/include/gtirb/Block.hpp
+++ b/include/gtirb/Block.hpp
@@ -62,7 +62,7 @@ public:
   static Block* Create(Context& C, CFG::vertex_descriptor Vertex, Addr Address,
                        uint64_t Size, Exit ExitKind = Exit::Fallthrough,
                        uint64_t DecodeMode = 0) {
-    return new (C) Block(C, Address, Size, Vertex, ExitKind, DecodeMode);
+    return C.Create<Block>(C, Address, Size, Vertex, ExitKind, DecodeMode);
   }
 
   /// \brief Get the address from a \ref Block.
@@ -117,6 +117,8 @@ private:
   CFG::vertex_descriptor Vertex;
   uint64_t DecodeMode{0};
   Exit ExitKind{Exit::Fallthrough};
+
+  friend class Context;
 };
 
 /// \ingroup CFG_GROUP

--- a/include/gtirb/DataObject.hpp
+++ b/include/gtirb/DataObject.hpp
@@ -49,7 +49,7 @@ public:
   /// be held.
   ///
   /// \return The newly created DataObject.
-  static DataObject* Create(Context& C) { return new (C) DataObject(C); }
+  static DataObject* Create(Context& C) { return C.Create<DataObject>(C); }
 
   /// \brief Create a DataObject object.
   ///
@@ -62,7 +62,7 @@ public:
   ///
   /// \return The newly created DataObject.
   static DataObject* Create(Context& C, Addr Address, uint64_t Size) {
-    return new (C) DataObject(C, Address, Size);
+    return C.Create<DataObject>(C, Address, Size);
   }
 
   /// \brief Get the address of a DataObject.
@@ -104,6 +104,8 @@ public:
 private:
   Addr Address{0};
   uint64_t Size{0};
+
+  friend class Context;
 };
 } // namespace gtirb
 

--- a/include/gtirb/IR.hpp
+++ b/include/gtirb/IR.hpp
@@ -120,7 +120,7 @@ public:
   /// \param C  The Context in which this object will be held.
   ///
   /// \return The newly created object.
-  static IR* Create(Context& C) { return new (C) IR(C); }
+  static IR* Create(Context& C) { return C.Create<IR>(C); }
 
   /// \brief Iterator over \ref Module "Modules".
   using iterator = boost::indirect_iterator<std::vector<Module*>::iterator>;
@@ -296,6 +296,8 @@ public:
 private:
   AuxDataSet AuxDatas;
   std::vector<Module*> Modules;
+
+  friend class Context;
 };
 } // namespace gtirb
 

--- a/include/gtirb/ImageByteMap.hpp
+++ b/include/gtirb/ImageByteMap.hpp
@@ -52,7 +52,7 @@ public:
   /// \param C  The Context in which this object will be held.
   ///
   /// \return The newly created object.
-  static ImageByteMap* Create(Context& C) { return new (C) ImageByteMap(C); }
+  static ImageByteMap* Create(Context& C) { return C.Create<ImageByteMap>(C); }
 
   /// \brief Set the base address of the loaded file.
   ///
@@ -323,6 +323,8 @@ private:
   Addr BaseAddress;
   Addr EntryPointAddress;
   boost::endian::order ByteOrder{boost::endian::order::native};
+
+  friend class Context;
 };
 
 /// \relates ImageByteMap

--- a/include/gtirb/Module.hpp
+++ b/include/gtirb/Module.hpp
@@ -100,7 +100,7 @@ public:
   /// \param C  The Context in which this object will be held.
   ///
   /// \return The newly created object.
-  static Module* Create(Context& C) { return new (C) Module(C); }
+  static Module* Create(Context& C) { return C.Create<Module>(C); }
 
   /// \brief Set the location of the corresponding binary on disk.
   ///
@@ -613,6 +613,8 @@ private:
   SymbolSet Symbols;
   SymbolAddrMap SymbolsByAddr;
   SymbolicExpressionSet SymbolicOperands;
+
+  friend class Context;
 };
 
 /// \relates Addr

--- a/include/gtirb/Node.hpp
+++ b/include/gtirb/Node.hpp
@@ -63,7 +63,7 @@ public:
   /// \param C  The Context in which this object will be held.
   ///
   /// \return The newly created object.
-  static Node* Create(Context& C) { return new (C) Node(C, Kind::Node); }
+  static Node* Create(Context& C) { return C.Create<Node>(C, Kind::Node); }
 
   /// \brief Cleans up resources no longer needed by the Node object.
   ~Node() noexcept;
@@ -100,6 +100,8 @@ private:
   // construction.
   void setUUID(UUID X);
   friend void setNodeUUIDFromBytes(Node* Node, const std::string& Bytes);
+
+  friend class Context;
 };
 
 } // namespace gtirb

--- a/include/gtirb/Section.hpp
+++ b/include/gtirb/Section.hpp
@@ -45,7 +45,7 @@ public:
   /// \param C  The Context in which this object will be held.
   ///
   /// \return The newly created object.
-  static Section* Create(Context& C) { return new (C) Section(C); }
+  static Section* Create(Context& C) { return C.Create<Section>(C); }
 
   /// \brief Create a Section object.
   ///
@@ -57,7 +57,7 @@ public:
   /// \return The newly created object.
   static Section* Create(Context& C, const std::string& Name, Addr Address,
                          uint64_t Size) {
-    return new (C) Section(C, Name, Address, Size);
+    return C.Create<Section>(C, Name, Address, Size);
   }
 
   /// \brief Equality operator overload.
@@ -107,6 +107,8 @@ private:
   std::string Name;
   Addr Address{0};
   uint64_t Size{0};
+
+  friend class Context;
 };
 } // namespace gtirb
 

--- a/include/gtirb/Symbol.hpp
+++ b/include/gtirb/Symbol.hpp
@@ -217,7 +217,7 @@ public:
   /// \param C  The Context in which this object will be held.
   ///
   /// \return The newly created object.
-  static Symbol* Create(Context& C) { return new (C) Symbol(C); }
+  static Symbol* Create(Context& C) { return C.Create<Symbol>(C); }
 
   /// \brief Create a Symbol object.
   ///
@@ -226,7 +226,7 @@ public:
   ///
   /// \return The newly created object.
   static Symbol* Create(Context& C, const std::string& Name) {
-    return new (C) Symbol(C, std::nullopt, Name);
+    return C.Create<Symbol>(C, std::nullopt, Name);
   }
 
   /// \brief Create a Symbol object.
@@ -240,7 +240,7 @@ public:
   /// \return The newly created object.
   static Symbol* Create(Context& C, Addr X, const std::string& Name,
                         StorageKind Kind = StorageKind::Extern) {
-    return new (C) Symbol(C, X, Name, Kind);
+    return C.Create<Symbol>(C, X, Name, Kind);
   }
 
   /// \brief Create a Symbol object.
@@ -258,7 +258,7 @@ public:
                         NodeTy* Referent,
                         StorageKind Kind = StorageKind::Extern) {
     static_assert(is_supported_type<NodeTy>(), "unsupported referent type");
-    return new (C) Symbol(C, X, Name, Referent, Kind);
+    return C.Create<Symbol>(C, X, Name, Referent, Kind);
   }
 
   /// \brief Get the effective address.
@@ -363,6 +363,8 @@ private:
   std::string Name;
   Symbol::StorageKind Storage{StorageKind::Extern};
   Node* Referent{nullptr};
+
+  friend class Context;
 };
 } // namespace gtirb
 

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -13,9 +13,22 @@
 //
 //===----------------------------------------------------------------------===//
 #include "Context.hpp"
+#include <gtirb/Block.hpp>
+#include <gtirb/DataObject.hpp>
+#include <gtirb/IR.hpp>
+#include <gtirb/ImageByteMap.hpp>
+#include <gtirb/Module.hpp>
 #include <gtirb/Node.hpp>
+#include <gtirb/Section.hpp>
+#include <gtirb/Symbol.hpp>
 
 using namespace gtirb;
+
+// By moving these declarations here, we avoid instantiating the default
+// ctor/dtor in other compilation units which include Context.hpp, where some
+// of the Node types may be incomplete.
+Context::Context() = default;
+Context::~Context() = default;
 
 void Context::unregisterNode(const Node* N) { UuidMap.erase(N->getUUID()); }
 
@@ -27,4 +40,29 @@ const Node* Context::findNode(const UUID& ID) const {
 Node* Context::findNode(const UUID& ID) {
   auto Iter = UuidMap.find(ID);
   return Iter != UuidMap.end() ? Iter->second : nullptr;
+}
+
+template <> void* Context::Allocate<Node>() const {
+  return NodeAllocator.Allocate();
+}
+template <> void* Context::Allocate<Block>() const {
+  return BlockAllocator.Allocate();
+}
+template <> void* Context::Allocate<DataObject>() const {
+  return DataObjectAllocator.Allocate();
+}
+template <> void* Context::Allocate<ImageByteMap>() const {
+  return ImageByteMapAllocator.Allocate();
+}
+template <> void* Context::Allocate<IR>() const {
+  return IrAllocator.Allocate();
+}
+template <> void* Context::Allocate<Module>() const {
+  return ModuleAllocator.Allocate();
+}
+template <> void* Context::Allocate<Section>() const {
+  return SectionAllocator.Allocate();
+}
+template <> void* Context::Allocate<Symbol>() const {
+  return SymbolAllocator.Allocate();
 }

--- a/src/test/Allocator.test.cpp
+++ b/src/test/Allocator.test.cpp
@@ -1,0 +1,61 @@
+//===- Allocator.test.cpp ---------------------------------------*- C++ -*-===//
+//
+//  Copyright (C) 2018 GrammaTech, Inc.
+//
+//  This code is licensed under the MIT license. See the LICENSE file in the
+//  project root for license terms.
+//
+//  This project is sponsored by the Office of Naval Research, One Liberty
+//  Center, 875 N. Randolph Street, Arlington, VA 22203 under contract #
+//  N68335-17-C-0700.  The content of the information does not necessarily
+//  reflect the position or policy of the Government and no official
+//  endorsement should be inferred.
+//
+//===----------------------------------------------------------------------===//
+
+#include <gtirb/Allocator.hpp>
+#include <array>
+#include <gtest/gtest.h>
+
+class AllocTest {
+public:
+  static size_t CtorCount;
+  static size_t DtorCount;
+
+  AllocTest() { CtorCount++; }
+  ~AllocTest() { DtorCount++; }
+
+  std::array<char, 7> Data; // Take up some space
+};
+size_t AllocTest::CtorCount = 0;
+size_t AllocTest::DtorCount = 0;
+
+using Allocator = SpecificBumpPtrAllocator<AllocTest>;
+
+inline void* operator new(size_t, Allocator& A) { return A.Allocate(); }
+inline void operator delete(void*, Allocator&) {}
+
+TEST(Unit_Allocator, allocate) {
+  AllocTest::CtorCount = AllocTest::DtorCount = 0;
+  Allocator A;
+  EXPECT_NE(new (A) AllocTest, nullptr);
+  EXPECT_NE(new (A) AllocTest, nullptr);
+  EXPECT_NE(new (A) AllocTest, nullptr);
+  EXPECT_EQ(AllocTest::CtorCount, 3);
+}
+
+TEST(Unit_Allocator, deallocate) {
+  // For varying numbers of allocations, ensure that destructors are called.
+  for (int AllocCount = 0; AllocCount < 100; AllocCount++) {
+    AllocTest::CtorCount = AllocTest::DtorCount = 0;
+    {
+      Allocator A;
+      EXPECT_NE(new (A) AllocTest, nullptr);
+      EXPECT_NE(new (A) AllocTest, nullptr);
+      EXPECT_NE(new (A) AllocTest, nullptr);
+      EXPECT_EQ(AllocTest::DtorCount, 0);
+    }
+    // All objects destroyed when allocator goes out of scope
+    EXPECT_EQ(AllocTest::DtorCount, AllocTest::CtorCount);
+  }
+}

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -23,6 +23,7 @@ set(${PROJECT_NAME}_H
 )
 
 set(${PROJECT_NAME}_SRC
+        Allocator.test.cpp
         Block.test.cpp
         ByteMap.test.cpp
         CFG.test.cpp


### PR DESCRIPTION
Adds a subclass of BumpPtrAllocatorImpl which only allocates a single
type, allowing it to walk the slabs and destroy objects during its own
destructor.

Context now has a separate allocator for each node type, with a
templated Allocate method which is specialized to use the correct
allocator.

The `Create` methods now call `Context::Allocate` explicitly, and use the built-in placement new rather than our own version. So this code:
```c++
return new (C) Module(C);
```
becomes this:
```c++
return new (C.Allocate<Module>()) Module(C);
```
This allows us to pass the type information down to the `Context`, so it can pick the right allocator.


There are two things which I don't really like about this design:

1. `DtorBumpPtrAllocator` is very dependent on the details of `BumpPtrAllocatorImpl`. But the public API is insufficient for our purposes, and it seems better to use an existing allocator which is presumably well-tested than to start from scratch. And in any event we aren't likely to make a lot of changes to this code. So I think this is ultimately the right way to go.

2. `DtorBumpPtrAllocator` is responsible for calling the destructors, but the various `Create` methods determine the type of the allocated object. So essentially, the two sides of the process are handled at different layers. One can imagine a copy-paste error leading to code like:
```c++
return new (C.Allocate<Module>()) MyNode(C);
```

This won't be detected at compile time and could lead to subtle errors. But this seems to be an unavoidable consequence of the way placement new works.