### PR TITLE
Expand gtirb protobuf documentation

### DIFF
--- a/PROTOBUF.md
+++ b/PROTOBUF.md
@@ -1,0 +1,139 @@
+Using Serialized GTIRB Data
+===========================
+
+The serialized [protobuf](https://github.com/google/protobuf/wiki)
+data produced by GTIRB allows for exploration and manipulation in the
+language of your choice. The [Google protocol
+buffers](https://developers.google.com/protocol-buffers/) homepage
+lists the languages in which protocol buffers can be used directly;
+users of other languages can convert the protobuf-formatted data to
+JSON format and then use the JSON data in their applications. In the
+future we intend to define a standard JSON schema for GTIRB.
+
+Directory `gtirb/src/proto' contains the protocol buffer message type
+definitions for GTIRB. You can inspect these `.proto` files to
+determine the structure of the various GTIRB message types. The
+top-level message type is `IR`.
+
+
+- [General Guidelines](#general-guidelines)
+- [Python Applications](#python-applications)
+- [Java Applications](#java-applications)
+
+
+# General Guidelines
+
+If you have not used protocol buffers before, there are several useful
+resources available at
+https://developers.google.com/protocol-buffers/, including an
+installation guide and a tutorial.
+
+In general, writing an application to use GTIRB data in protocol
+buffer format will involve the following steps.
+
+1. Install the protocol buffer compiler (`protoc`) from
+   https://github.com/protocolbuffers/protobuf/releases, if you
+   haven't already done so.
+
+2. Install any required protocol buffer library or libraries for the
+   programming language you are using.
+
+3. Invoke the protocol buffer compiler on the `.proto` files in
+   `gtirb/src/proto/` to generate code in the language you wish to use.
+
+4. Write your application, importing/including the file or files you
+   generated in step 3.
+
+The [Protocol Buffers API
+Reference](https://developers.google.com/protocol-buffers/docs/reference/overview)
+provides language-specific instructions for the various supported
+programming languages, along with links to information for cases where
+support is provided by third-party plug-ins.
+
+
+# Python Applications
+
+To create a Python application that uses serialized GTIRB data, do the
+following.
+
+1. Install the protocol buffer compiler (`protoc`).
+
+2. Install the Python protobuf library, if you haven't already done so.
+
+       $ pip install protobuf
+
+3. Generate Python message definitions in a dedicated directory (for
+   example, `python/`).
+
+       $ mkdir -p python
+       $ for f in src/proto/*.proto; do
+            protoc -Isrc/proto --python_out=python $f
+         done
+     
+   This will create a number of files with names of the form
+   `<bn>_pb2.py` in the `python/` subdirectory of your working
+   directory: one for each `<bn>.proto` in src/proto/, including
+   `IR_pb2.py`.
+
+4. Write your application. Make sure that it imports `IR_pb2`, or the
+   parts of it that you require.
+
+5. Run your application, making sure that the directory containing
+   your message definitions is in the `PYTHONPATH`.
+
+## Python Examples
+
+Directory `gtirb/doc/examples` contains several example Python scripts
+that use protocol buffers to explore serialized GTIRB data.
+- [cfg-paths.py](doc/examples/cfg-paths.py)
+- [data-symbols.py](doc/examples/data-symbols.py)
+
+
+# Java Applications
+
+
+To create a Java application that uses serialized GTIRB data, do the
+following.
+
+1. Install the protocol buffer compiler (`protoc`).
+
+2. Download the `protobuf` Java runtime from
+   [https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java](https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java)
+   and save it somewhere suitable.
+
+3. Generate Java message definitions in a dedicated directory (for example,
+   `java/`).
+
+       $ mkdir -p java
+       $ for f in src/proto/*.proto; do
+            protoc -Isrc/proto --java_out=java $f
+         done
+     
+   This will create a subdirectory `java/proto/', containing a number
+   of files with names of the form `<bn>OuterClass.java`: one for each
+   `<bn>.proto` in `src/proto/`.
+
+4. Compile the Java message definitions, making sure the `protobuf`
+   Java runtime `.jar` file is in your `CLASSPATH`.
+
+     $ mkdir -p java/classfiles
+     $ CLASSPATH=<path/to/protobuf_jar> \
+       javac -d java/classfiles java/proto/*.java 
+
+   (If you want to build a `.jar` file to combine all these
+   `.class` files, do so at this stage.)
+
+5. Write your application. Make sure that it imports all the classes
+   you need from the `proto` package.
+
+6. Compile and run your application, making sure that your CLASSPATH
+   contains both the `protobuf` Java runtime `.jar` file and the
+   location of the your compiled message definition classes.
+
+
+## Java Examples
+
+Directory `gtirb/doc/examples` contains several example Java programs
+that use protocol buffers to explore serialized GTIRB data.
+
+- [datasymbols.java](doc/examples/datasymbols.java)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ GTIRB is modeled on LLVM-IR, and seeks to serve a similar
 functionality of encouraging communication and interoperability
 between tools.
 
-The remainder of this file has information on GTIRB's:
+The remainder of this file describes various aspects of GTIRB:
 - [Structure](#structure)
 - [Building](#building)
 - [Usage](#usage)
@@ -32,13 +32,14 @@ GTIRB has the following structure:
 
 ### IR
 
-An instance of GTIRB may include multiple `module`s which represent
-loadable objects such as executables or libraries.  Each `module`
-holds information such as `symbol`s, `data`, and an inter-procedural
-control flow graph (`ICFG`).  The `ICFG` consists of basic `block`s
-and control flow edges between these `block`s.  Each `datum` and
-`block` holds both a pointer to a range of bytes in the `ImageByteMap`
-and `symbolic` information coverage that range.
+An instance of GTIRB may include multiple modules (`Module`) which
+represent loadable objects such as executables or libraries.  Each
+module holds information such as symbols (`Symbol`), data (`Data`),
+and an inter-procedural control flow graph (`ICFG`).  The ICFG
+consists of basic blocks (`Block`) and control flow edges between
+these blocks.  Each datum and each block holds both a pointer to a
+range of bytes in the `ImageByteMap` and symbolic (`Symbol`)
+information covering this range.
 
 
 ### Instructions
@@ -76,14 +77,13 @@ GTIRB should successfully build in 64-bits with GCC, Clang, and Visual
 Studio compilers supporting at least C++17.  GTIRB uses CMake which
 must be installed.
 
-```sh
-mkdir build
-cd build
-cmake ../path/to/gtirb
-make -j
-# Run the test suite.
-./bin/TestGTIRB
-```
+    sh
+    mkdir build
+    cd build
+    cmake ../path/to/gtirb
+    make -j
+    # Run the test suite.
+    ./bin/TestGTIRB
 
 The gtirb library will be located in `lib/libgtirb.so` in the build
 directory.
@@ -92,22 +92,51 @@ directory.
 ## Usage
 
 GTIRB is designed to be serialized using [Google's protocol
-Buffers](https://developers.google.com/protocol-buffers/) (i.e.,
-[protobuf](https://github.com/google/protobuf/wiki)) and using JSON
-through protobuf's JSON output.  These two options should enable easy
-and efficient use of GTIRB from any programming language.  GTIRB may
-also be used as a C++ library implementing an efficient data structure
-suitable for use by binary analysis and rewriting applications.
+buffers](https://developers.google.com/protocol-buffers/) (i.e.,
+[protobuf](https://github.com/google/protobuf/wiki)), enabling [easy
+and efficient use from any programming language](#using-serialized-gtirb-data).
 
-This repository defines the GTIRB data structure and C++ library API.
+GTIRB may also be [used as a C++ library](#using-the-c++-api)
+implementing an efficient data structure suitable for use by binary
+analysis and rewriting applications.
+
+- [Using Serialized GTIRB Data](#using-serialized-gtirb-data)
+- [Using the C++ Library](#using-the-c++-library)
+
+### Using Serialized GTIRB Data
+
+The serialized [protobuf](https://github.com/google/protobuf/wiki)
+data produced by GTIRB allows for exploration and manipulation in the
+language of your choice. The [Google protocol
+buffers](https://developers.google.com/protocol-buffers/) homepage
+lists the languages in which protocol buffers can be used directly;
+users of other languages can convert the protobuf-formatted data to
+JSON format and then use the JSON data in their applications. In the future we intend to define a standard JSON schema for GTIRB.
+
+Directory `gtirb/src/proto' contains the protocol buffer message type
+definitions for GTIRB. You can inspect these `.proto` files to
+determine the structure of the various GTIRB message types. The
+top-level message type is `IR`.
+
+For more details, see [Using Serialized GTIRB Data](PROTOBUF.md)
+
+
+### Using the C++ Library
+
+We have provided several C++ examples in directory
+`gtirb/doc/examples`. See the [Examples tab](examples.html) for more
+information.
+
 The remainder of this section provides examples walking through common
 tasks using the GTIRB C++ library API.
+
 
 - [Populating the IR](#populating-the-ir)
 - [Querying the IR](#querying-the-ir)
 - [Serialization](#serialization)
 
-### Populating the IR
+
+#### Populating the IR
 
 GTIRB objects are created within a `Context` object. Freeing the
 `Context` will also destroy all the objects within it.
@@ -222,7 +251,7 @@ ir.addAuxData("stringMap", std::map<std::string, std::string>(
 ```
 
 
-### Querying the IR
+#### Querying the IR
 
 Symbols can be looked up by address or name.  Any number of symbols
 can share an address or name, so be prepared to deal with multiple
@@ -303,8 +332,7 @@ for (auto p : *stringMap) {
 }
 ```
 
-
-### Serialization
+#### Serialization
 
 Serialize IR to a file:
 

--- a/doc/doxy/CMakeLists.txt
+++ b/doc/doxy/CMakeLists.txt
@@ -52,7 +52,7 @@ add_custom_command(OUTPUT ${DOTFILES}
 # ----------------------------------------------------------------------
 
 
-set(MDFILES_IN "${DOC_INDIR}/CFG-Edges.md" "${ROOTDIR}/CONTRIBUTING.md" "${ROOTDIR}/README.md")
+set(MDFILES_IN "${DOC_INDIR}/CFG-Edges.md" "${ROOTDIR}/CONTRIBUTING.md" "${ROOTDIR}/PROTOBUF.md" "${ROOTDIR}/README.md")
 
 set(MDFILES ${MDFILES_IN})
 move_filename(MDFILES ${CMAKE_CURRENT_BINARY_DIR})

--- a/doc/doxy/Doxyfile.in
+++ b/doc/doxy/Doxyfile.in
@@ -785,7 +785,7 @@ WARN_LOGFILE           = doxygen_warnings.txt
 # TOC (otherwise it will be alphabetical)
 
 INPUT   = @CMAKE_CURRENT_SOURCE_DIR@/../../include @CMAKE_CURRENT_SOURCE_DIR@/../dot
-INPUT   += README.md CFG-Edges.md CONTRIBUTING.md 
+INPUT   += README.md PROTOBUF.md CFG-Edges.md CONTRIBUTING.md 
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/doc/doxy/Doxyfile.in
+++ b/doc/doxy/Doxyfile.in
@@ -900,7 +900,7 @@ EXCLUDE_SYMBOLS        = proto
 # that contain example code fragments that are included (see the \include
 # command).
 
-EXAMPLE_PATH           = ../doc/examples
+EXAMPLE_PATH           = @CMAKE_CURRENT_SOURCE_DIR@/../examples
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp and

--- a/doc/doxy/preprocmd.py
+++ b/doc/doxy/preprocmd.py
@@ -36,6 +36,10 @@ with open(infile,'r') as infh:
          (r'\n( +)```bash(\n(.*\n)*?)\1```',
           lambda m: m.group(1) + m.group(2).replace('\n','\n    ')),
 
+         # .md file links to /doc/examples/* become Doxygen \ref
+         # links with no path component         
+         (r'\[([^]\n]*)\]\s*\(doc/examples/(.*?)\)',
+          r'\\ref \2 "\1"'), 
 
          # C++ has to be converted to doxygen \code ...\endcode to get
          # linking

--- a/doc/examples/cfg-paths.py
+++ b/doc/examples/cfg-paths.py
@@ -3,7 +3,6 @@
 # An example program which opens an IR and prints every control-flow
 # path from some basic block to another basic block.
 #
-
 # To run this example, do the following.
 #
 # 1. Install the protobuf compiler (protoc) from
@@ -40,24 +39,33 @@ import sys
 
 from IR_pb2 import IR
 
+# Avoid duplicated effort by caching the uuids of Blocks from
+# which we have know the target is unreachable.
+unreachability_cache = set([])
+
 def print_paths(blocks, edges, target_id, vertex_id, visited=set(), path=[]):
     """Depth-first search of a graph, printing all paths between two vertices."""
-
+    rv = 0
     visited.add(vertex_id)
     path.append(blocks[vertex_id].address)
 
     # At target, print the path
     if vertex_id == target_id:
         print(', '.join('0x%.8x' % s for s in path))
+        rv= 1
+    
+    # Otherwise, check all outgoing edges from this vertex
     else:
-        # Otherwise, check all outgoing edges from this vertex
         for v in edges[vertex_id]:
-            if v not in visited:
-                print_paths(blocks, edges, target_id, v, visited, path)
+            if v not in visited and v not in unreachability_cache:
+                rv += print_paths(blocks, edges, target_id, v, visited, path)
 
     path.pop()
     # Unmark the node so it can be visited again in other paths
     visited.discard(vertex_id)
+    if rv==0:
+        unreachability_cache.add(vertex_id)
+    return rv
 
 def auto_int(x):
     return int(x, 0)
@@ -69,29 +77,51 @@ parser.add_argument('source', type=auto_int, help='Address of the source block')
 parser.add_argument('target', type=auto_int, help='Address of the target block')
 args = parser.parse_args()
 
+def find_block(addr,mod):
+    return next((b for b in mod.cfg.blocks if b.address == addr), None)
+
 ir = IR()
 ir.ParseFromString(args.ir.read())
 
-m = ir.modules[0]
 
-def find_block(addr):
-    return next((b for b in m.cfg.blocks if b.address == addr), None)
-source_block = find_block(args.source)
-target_block = find_block(args.target)
+oneblock_fmt = "{0}-block {1:08X} is located in a module that does not contain  {2}-block {3:08X}.\nThe {2}-block may be in a different module, or may not exist."
 
-if source_block is None:
-    print('No block at source address 0x%.8x' % args.source, file=sys.stderr)
+found = False
+# Check one module at a time (the GTIRB CFGs do not have edges across
+# module boundaries, so if the specified blocks are in different
+# modules there cannot be any paths between them).
+for m in ir.modules:
+    source_block = find_block(args.source, m)
+    target_block = find_block(args.target, m)
+
+    # neither block is in current module: go on to next
+    if (source_block is None) and (target_block is None):
+        continue
+
+    # only one block is in current module: there cannot be any paths.
+    if source_block is None:
+        print(oneblock_fmt.format('target', args.target, 'source', args.source))
+        sys.exit(1)
+    if target_block is None:
+        print(oneblock_fmt.format('source', args.source, 'target', args.target))
+        sys.exit(1)
+
+    # if execution reaches this point, both blocks are in current module
+    found=True
+    
+    # Convert the CFG to a simple adjacency list
+    blocks = { b.uuid: b for b in m.cfg.blocks }
+    edges = collections.defaultdict(list)
+    for e in m.cfg.edges:
+        edges[e.source_uuid].append(e.target_uuid)
+
+    print("Paths from {0:08X} to {1:08X}".format(source_block.address,
+                                                 target_block.address))
+    num = print_paths(blocks, edges, target_block.uuid, source_block.uuid)
+
+    print(num, "paths found.")
+    break
+
+if not found:
+    print("Neither block was found:\n source {0:08X}\n target {1:08X}".format(args.source, args.target))
     sys.exit(1)
-
-if target_block is None:
-    print('No block at target address 0x%.8x' % args.target, file=sys.stderr)
-    sys.exit(1)
-
-# Convert the CFG to a simple adjacency list
-blocks = { b.uuid: b for b in m.cfg.blocks }
-edges = collections.defaultdict(list)
-for e in m.cfg.edges:
-    edges[e.source_uuid].append(e.target_uuid)
-
-print('Paths from %.8x to %.8x:' % (source_block.address, target_block.address))
-print_paths(blocks, edges, target_block.uuid, source_block.uuid)

--- a/doc/examples/cfg-paths.py
+++ b/doc/examples/cfg-paths.py
@@ -3,17 +3,34 @@
 # An example program which opens an IR and prints every control-flow
 # path from some basic block to another basic block.
 #
-# Before using this, install the python protobuf library and generate
-# message definitions:
+
+# To run this example, do the following.
 #
-# $ pip install protobuf
-# $ mkdir -p python
-# $ for f in src/proto/*.proto; do
-#      protoc -Isrc/proto --python_out=python $f
-#   done
+# 1. Install the protobuf compiler (protoc) from
+#    https://github.com/protocolbuffers/protobuf/releases (if you have
+#    not already done so).
 #
-# Then run the program like this:
-# $ PYTHONPATH=./python/ ./doc/examples/cfg-paths.py <path-to-ir> <source-addr> <target-addr>
+# 2. Install the Python protobuf library (if you have not already done so).
+#
+#    $ pip install protobuf
+#
+# 3. Generate message definitions.
+#
+#    $ mkdir -p python
+#    $ for f in src/proto/*.proto; do
+#         protoc -Isrc/proto --python_out=python $f
+#      done
+#
+#    This will create a number of files with names of the form
+#    <bn>_pb2.py in the python/ subdirectory of your working directory
+#    - one for each <bn>.proto in src/proto/ - including IR_pb2.py.
+#
+# 4. Execute the following command to run the program on the
+#    serialized GTIRB data located at <path-to-ir>, printing every
+#    control-flow path between the block with address <source-addr>
+#    and the block with address <target-addr>.
+#
+#    $ PYTHONPATH=./python/ ./doc/examples/cfg-paths.py <path-to-ir> <source-addr> <target-addr>
 
 
 from __future__ import print_function
@@ -46,7 +63,7 @@ def auto_int(x):
     return int(x, 0)
 
 parser = argparse.ArgumentParser(description='Print CFG paths between two blocks.')
-parser.add_argument('ir', type=argparse.FileType('r'),
+parser.add_argument('ir', type=argparse.FileType('rb'),
                     help='The IR to load')
 parser.add_argument('source', type=auto_int, help='Address of the source block')
 parser.add_argument('target', type=auto_int, help='Address of the target block')

--- a/doc/examples/cfgpaths.java
+++ b/doc/examples/cfgpaths.java
@@ -1,0 +1,233 @@
+// An example program which opens an IR and prints every control-flow
+// path from some basic block to another basic block.
+//
+// To run this example, do the following.
+//
+// 1. Install the protobuf compiler (protoc) from
+//    https://github.com/protocolbuffers/protobuf/releases (if you have
+//    not already done so).
+//
+// 2. Download the protobuf Java runtime from
+//    https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java
+//    and save it somewhere suitable.
+//
+// 3. Generate Java message definitions.
+//
+//    $ mkdir -p java $ for f in src/proto/*.proto; do
+//         protoc -Isrc/proto --java_out=java $f
+//      done
+//
+//    This will create a subdirectory java/proto/, containing a
+//    number of files with names of the form <bn>OuterClass.java:
+//    one for each <bn>.proto in src/proto/.
+//
+// 4. Compile the Java message definitions, making sure the protobuf
+//    Java runtime .jar file is in your CLASSPATH.
+//
+//    $ mkdir -p java/classfiles
+//    $ CLASSPATH=<path/to/protobuf_jar> \
+//         javac -d java/classfiles java/proto/*.java
+//
+// 5. Compile the datasymbols class defined in this file, making sure
+//    your CLASSPATH contains both the Java runtime .jar file and the
+//    compiled Java message definition classes.
+//    (Note that the path separator is OS-dependent.)
+//
+//    $ CLASSPATH=<path/to/protobuf_jar>:./java/classfiles/ \
+//         javac doc/examples/cfgpaths.java
+//
+// 6. Execute the following command to run the program on the
+//    serialized GTIRB data located at <path-to-ir> printing every
+//    control-flow path between the block with address <source-addr>
+//    and the block with address <target-addr>.
+//
+//    $  CLASSPATH=<path/to/protobuf_jar>:./java/classfiles/:doc/examples/ \
+//          java cfgpaths <path-to-ir>  <source-addr> <target-addr>
+
+import com.google.protobuf.ByteString; 
+import proto.IROuterClass.IR;
+import proto.BlockOuterClass.Block;
+import proto.CFGOuterClass.CFG;
+import proto.CFGOuterClass.Edge;
+import proto.ModuleOuterClass.Module; 
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.*;  
+import java.lang.Long;  
+
+class cfgpaths {
+
+    // Avoid duplicated effort by caching the uuids of Blocks from
+    // which we have the target is unreachable.
+    static Set<ByteString> unreachability_cache = new HashSet<ByteString>();
+
+    // Print one path.
+    static void printPath(Stack<Long> path){
+	Set<Long> pathset = new HashSet<Long>();
+	pathset.addAll(path);
+	//	assert path.size() == pathset.size(); 
+	for (Long addr : path){
+	    System.out.print(String.format("0x%08X ", addr));
+	}
+	System.out.println();
+    }
+
+    // Use depth-first search to print all paths from the Block with
+    // uuid src to targ to the Block with uuid targ.
+    static int printPathsRec(ByteString src,
+			     ByteString targ,
+			     Map<ByteString,Block> blocks,
+			     Map<ByteString,Set<ByteString>> edges,
+			     Set<ByteString> visited,
+			     Stack<Long> path){
+
+	int printed=0;
+	path.push(blocks.get(src).getAddress());	
+	visited.add(src);
+	if (src.equals(targ)){
+	    printPath(path);
+	    printed = 1;
+	} else{
+	    for (ByteString next : edges.get(src)) {
+		if ( !visited.contains(next) 
+		     && !unreachability_cache.contains(next)){
+		    printed += printPathsRec(next,
+					     targ,
+					     blocks,
+					     edges,
+					     visited,
+					     path);
+		}
+	    }
+	}
+	visited.remove(src);
+	path.pop();
+	if (printed==0){
+	    unreachability_cache.add(src);
+	}
+	return printed;
+    }
+
+    // Print all paths from source to target in cfg.
+    static void printPaths(Block source, Block target, CFG cfg){
+	Map<ByteString,Block> blocks = new HashMap<ByteString,Block>();
+	Map<ByteString,Set<ByteString>> edges = new HashMap<ByteString,Set<ByteString>>();
+	Set<ByteString> visited = new HashSet<ByteString>();
+
+	for (Block b : cfg.getBlocksList()){
+	    blocks.put(b.getUuid(), b);
+	    edges.put(b.getUuid(), new HashSet<ByteString>());
+	}
+
+	for (Edge e : cfg.getEdgesList()){
+	    edges.get(e.getSourceUuid()).add(e.getTargetUuid());
+	}
+	
+	int numpaths = printPathsRec(source.getUuid(),
+				     target.getUuid(),
+				     blocks,
+				     edges,
+				     new HashSet<ByteString>(),
+				     new Stack<Long>());
+	System.out.println(numpaths + " paths found.");
+    }
+
+
+    static Block findBlockByAddr(Long addr, CFG cfg){
+	for (Block b : cfg.getBlocksList()){
+	    if (b.getAddress() == addr){
+		return b;
+	    }
+	}
+	return Block.getDefaultInstance();
+    }
+
+    public static void main(String[] args) {
+
+        IR ir = IR.getDefaultInstance();
+	Block defaultblock = Block.getDefaultInstance();
+	Block from_block = defaultblock;
+	Block to_block = defaultblock;
+	CFG cfg = CFG.getDefaultInstance();
+	boolean blocks_found = false;
+	Long from_addr =-1L;
+	Long to_addr =-1L;
+	
+
+        if (args.length < 3){
+            System.err.println("Requires three arguments: <gtirb-file> <from-address> <to-address> ");
+            System.exit(-1);
+        }
+
+        // Read serialized GTIRB data from the specified file.
+        try {
+            ir = IR.parseFrom(new FileInputStream(args[0]));
+        } catch (FileNotFoundException fe) {
+            System.err.println("File not found: " + args[0]);
+            System.exit(-1);
+        } catch (IOException ie) {
+            System.err.println("Problem reading file: " + args[0]);
+            System.exit(-1);
+        }
+
+	try {
+	    from_addr = Long.decode(args[1]);
+	    to_addr = Long.decode(args[2]);
+	} catch (NumberFormatException nfe) {
+            System.err.println("Specify block addresses as numbers in decimal, hexadecimal, or octal format.");
+            System.exit(-1);
+        }
+
+	// Check one module at a time (the GTIRB CFGs do not have
+	// edges across module boundaries, so if the specified blocks
+	// are in different modules there cannot be any paths between
+	// them).
+        for (Module m : ir.getModulesList()) {
+	    cfg = m.getCfg();
+	    from_block = findBlockByAddr(from_addr, cfg);
+	    to_block = findBlockByAddr(to_addr, cfg);
+
+	    // Neither block is in this module: go on to next module.
+	    if (from_block==defaultblock && to_block==defaultblock){
+		System.out.println("Blocks not found in module " + m.getName());
+		continue;
+	    }
+
+	    // One block is in this module and the other isn't: error.
+	    if (to_block==defaultblock){
+		System.err.println(String.format("The block at from-address 0x%08X is located in a module that does not contain a block at to-address 0x%08X.  The block at 0x%08X may be in a different module, or may not exist.", 
+						 from_addr, 
+						 to_addr, 
+						 to_addr));
+		System.exit(-1);
+	    }
+	    if (from_block==defaultblock){
+		System.err.println(String.format("The block at  to-address 0x%08X is located in a module that does not contain a block at from-address 0x%08X. The block at 0x%08X may be in a different module, or may not exist.",  
+						 to_addr,  
+						 from_addr,  
+						 from_addr));
+		System.exit(-1);
+	    }
+
+	    // At this point, both to_block and from_block must be
+	    // present in this module.
+	    blocks_found = true;
+	    System.out.println("Blocks found in module " + m.getName());
+	    printPaths(from_block, to_block, cfg);
+	    break;
+	}
+
+	// If never found either block, notify user.
+	if (!blocks_found){
+	    System.err.println(String.format("No blocks found at either of the specified addresses: \n to-address: 0x%08X \n from-address: 0x%08X", 
+					     to_addr, 
+					     from_addr));
+	    System.exit(-1);
+	}
+    }
+}
+
+
+

--- a/doc/examples/data-symbols.py
+++ b/doc/examples/data-symbols.py
@@ -3,17 +3,31 @@
 # An example program which opens an IR and prints information about all
 # symbols pointing to data.
 #
-# Before using this, install the python protobuf library and generate
-# message definitions:
+# To run this example, do the following.
 #
-# $ pip install protobuf
-# $ mkdir -p python
-# $ for f in src/proto/*.proto; do
-#      protoc -Isrc/proto --python_out=python $f
-#   done
+# 1. Install the protobuf compiler (protoc) from
+#    https://github.com/protocolbuffers/protobuf/releases (if you have
+#    not already done so).
 #
-# Then run the program like this:
-# $ PYTHONPATH=./python/ ./doc/examples/data-symbols.py <path-to-ir>
+# 2. Install the Python protobuf library (if you have not already done so).
+#
+#    $ pip install protobuf
+#
+# 3. Generate message definitions.
+#
+#    $ mkdir -p python
+#    $ for f in src/proto/*.proto; do
+#         protoc -Isrc/proto --python_out=python $f
+#      done
+#
+#    This will create a number of files with names of the form
+#    <bn>_pb2.py in the python/ subdirectory of your working directory
+#    - one for each <bn>.proto in src/proto/ - including IR_pb2.py.
+#
+# 4. Execute the following command to run the program on the
+#    serialized GTIRB data located at <path-to-ir>.
+#
+#    $ PYTHONPATH=./python/ ./doc/examples/data-symbols.py <path-to-ir>
 
 from __future__ import print_function
 import sys
@@ -21,7 +35,7 @@ import sys
 from IR_pb2 import IR
 
 ir = IR()
-with open(sys.argv[1]) as f:
+with open(sys.argv[1],'rb') as f:
     ir.ParseFromString(f.read())
 
 for m in ir.modules:

--- a/doc/examples/datasymbols.java
+++ b/doc/examples/datasymbols.java
@@ -1,0 +1,106 @@
+// An example program which opens an IR and prints information about all
+// symbols pointing to data.
+//
+// To run this example, do the following.
+//
+// 1. Install the protobuf compiler (protoc) from
+//    https://github.com/protocolbuffers/protobuf/releases (if you have
+//    not already done so).
+//
+// 2. Download the protobuf Java runtime from
+//    https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java
+//    and save it somewhere suitable.
+//
+// 3. Generate Java message definitions.
+//
+//    $ mkdir -p java $ for f in src/proto/*.proto; do
+//         protoc -Isrc/proto --java_out=java $f
+//      done
+//
+//    This will create a subdirectory java/proto/, containing a
+//    number of files with names of the form <bn>OuterClass.java:
+//    one for each <bn>.proto in src/proto/.
+//
+// 4. Compile the Java message definitions, making sure the protobuf
+//    Java runtime .jar file is in your CLASSPATH.
+//
+//    $ mkdir -p java/classfiles
+//    $ CLASSPATH=<path/to/protobuf_jar> \
+//         javac -d java/classfiles java/proto/*.java
+//
+// 5. Compile the datasymbols class defined in this file, making sure
+//    your CLASSPATH contains both the Java runtime .jar file and the
+//    compiled Java message definition classes.
+//    (Note that the path separator is OS-dependent.)
+//
+//    $ CLASSPATH=<path/to/protobuf_jar>:./java/classfiles/ \
+//         javac -classpath  doc/examples/datasymbols.java
+//
+// 6. Execute the following command to run the program on the
+//    serialized GTIRB data located at <path-to-ir>.
+//
+//    $  CLASSPATH=<path/to/protobuf_jar>:./java/classfiles/:doc/examples/ \
+//          java datasymbols <path-to-ir>
+
+import com.google.protobuf.ByteString;
+import proto.IROuterClass.IR;
+import proto.ModuleOuterClass.Module;
+import proto.DataObjectOuterClass.DataObject;
+import proto.SymbolOuterClass.Symbol;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.*;
+import java.lang.Long;
+
+class datasymbols {
+
+    public static void main(String[] args) {
+
+        IR ir = IR.getDefaultInstance();
+        DataObject data_obj;
+
+        if (args.length < 1){
+            System.err.println("No GTIRB file specified.");
+            System.exit(-1);
+        }
+
+        // Read serialized GTIRB data from the specified file.
+        try {
+            ir = IR.parseFrom(new FileInputStream(args[0]));
+        } catch (FileNotFoundException fe) {
+            System.err.println("File not found: " + args[0]);
+            System.exit(-1);
+        } catch (IOException ie) {
+            System.err.println("Problem reading file: " + args[0]);
+            System.exit(-1);
+        }
+
+
+        for (Module m : ir.getModulesList()) {
+
+            // Print the name of each Module.
+            System.out.println("Module " + m.getName());
+
+            // Make a map uuid->DataObject for the Module.
+            Map<Long, DataObject> datamap = m.getDataMap();
+            Map<ByteString, DataObject> data_objects = new HashMap<ByteString,DataObject>();
+            for (DataObject d : datamap.values()){
+            data_objects.put(d.getUuid(), d);
+            }
+
+            // Examine all symbols in the module
+            for (Symbol sym : m.getSymbolsList()) {
+                data_obj = data_objects.get(sym.getReferentUuid());
+                if (data_obj!=null){
+                    // If the symbol refers to data, print some information about it
+                    System.out.println(String.format("%s:\t0x%08X\t %d bytes",
+                                                     sym.getName(),
+                                                     data_obj.getAddress(),
+                                                     data_obj.getSize()));
+                }
+            }
+        }
+    }
+}

--- a/include/gtirb/Block.hpp
+++ b/include/gtirb/Block.hpp
@@ -56,7 +56,6 @@ public:
   /// \param Size       The size of the Block in bytes.
   /// \param ExitKind   Indicates how control flow exits the block.
   /// \param DecodeMode The decode mode of the Block.
-
   ///
   /// \return The newly created Block.
   static Block* Create(Context& C, CFG::vertex_descriptor Vertex, Addr Address,
@@ -67,12 +66,18 @@ public:
 
   /// \brief Get the address from a \ref Block.
   ///
-  /// \return The address.
+  /// \return The address of the start of the block.
+  ///
+  /// Use with Block::getSize() to obtain arguments to pass to
+  /// ByteMap::data() for an iterator over the contents of a \ref Block.
   Addr getAddress() const { return Address; }
 
   /// \brief Get the size from a \ref Block.
   ///
   /// \return The size in bytes.
+  ///
+  /// Use with Block::getAddress() to obtain arguments to pass to
+  /// ByteMap::data() for an iterator over the contents of a \ref Block.
   uint64_t getSize() const { return Size; }
 
   /// \brief Get a vertex descriptor which can be used to locate the Block

--- a/include/gtirb/ByteMap.hpp
+++ b/include/gtirb/ByteMap.hpp
@@ -68,6 +68,10 @@ public:
   /// \return An iterator range that encodes a contiguous block of memory that
   /// can be accessed directly, such as via memcpy(). Will return an empty
   /// range if the requested address or number of bytes cannot be retrieved.
+  ///
+  /// For an interator over the contents of a \ref Block, use
+  /// Block::getAddress() and Block::getSize() to obtain the arguments
+  /// to this method.
   const_range data(Addr A, size_t Bytes) const;
 
   /// \brief The protobuf message type used for serializing ByteMap.

--- a/include/gtirb/IR.hpp
+++ b/include/gtirb/IR.hpp
@@ -95,6 +95,9 @@ class Module;
 /// Open an IR via protobuf and print every path from some point to some
 /// other point.
 
+/// \example datasymbols.java
+/// Open an IR via protobuf and print every symbol pointing to data.
+
 class GTIRB_EXPORT_API IR : public Node {
   IR(Context& C) : Node(C, Kind::IR) {}
 


### PR DESCRIPTION
- Add a new page about using the protobuf output.
- Polish in-file documentation for .py examples.
- Modify .py examples to open files in 'rb' mode (didn't work for me
  otherwise).
- Add a .java example.
- Also: minor expansion of API documentation for Block.

TODO:
- A .java version of the cfg-paths example.
- Maybe coverage for further languages in PROTOBUF.md, examples?
- Figure out why Doxygen is trying to link the proto namespace in the
  Java example despite 'proto' supposedly being an excluded symbol.

IP:Debloat