### PR TITLE
Update googletest version

### DIFF
--- a/CMakeLists.googletest
+++ b/CMakeLists.googletest
@@ -6,7 +6,7 @@ include(ExternalProject)
 externalproject_add(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG release-1.10.0
+  GIT_TAG v1.15.2
   SOURCE_DIR "${CMAKE_BINARY_DIR}/googletest-src"
   BINARY_DIR "${CMAKE_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
Currently, building the project as debug will fail due to an uninitialized object in googletest's source tree. By raising googletest version, this error can be solved.